### PR TITLE
solve issue #29 (from tcatm): don't bail out without nl80211

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -71,7 +71,9 @@ void loop(struct l3ctx *ctx) {
 	add_fd(efd, ctx->icmp6_ctx.nsfd, EPOLLIN);
 	add_fd(efd, ctx->arp_ctx.fd, EPOLLIN);
 	add_fd(efd, ctx->intercom_ctx.fd, EPOLLIN | EPOLLET);
-	add_fd(efd, ctx->wifistations_ctx.fd, EPOLLIN);
+	if (ctx->wifistations_ctx.fd) {
+		add_fd(efd, ctx->wifistations_ctx.fd, EPOLLIN);
+	}
 
 	/* Buffer where events are returned */
 	events = calloc(maxevents, sizeof(struct epoll_event));
@@ -105,7 +107,8 @@ void loop(struct l3ctx *ctx) {
 					intercom_handle_in(&ctx->intercom_ctx, events[i].data.fd);
 			} else if (ctx->taskqueue_ctx.fd == events[i].data.fd) {
 				taskqueue_run(&ctx->taskqueue_ctx);
-			} else if (ctx->wifistations_ctx.fd == events[i].data.fd) {
+			} else if (ctx->wifistations_ctx.fd
+				  && ctx->wifistations_ctx.fd == events[i].data.fd) {
 				wifistations_handle_in(&ctx->wifistations_ctx);
 			}
 		}

--- a/src/main.c
+++ b/src/main.c
@@ -71,7 +71,7 @@ void loop(struct l3ctx *ctx) {
 	add_fd(efd, ctx->icmp6_ctx.nsfd, EPOLLIN);
 	add_fd(efd, ctx->arp_ctx.fd, EPOLLIN);
 	add_fd(efd, ctx->intercom_ctx.fd, EPOLLIN | EPOLLET);
-	if (ctx->wifistations_ctx.fd) {
+	if (ctx->wifistations_ctx.fd >= 0) {
 		add_fd(efd, ctx->wifistations_ctx.fd, EPOLLIN);
 	}
 
@@ -107,8 +107,7 @@ void loop(struct l3ctx *ctx) {
 					intercom_handle_in(&ctx->intercom_ctx, events[i].data.fd);
 			} else if (ctx->taskqueue_ctx.fd == events[i].data.fd) {
 				taskqueue_run(&ctx->taskqueue_ctx);
-			} else if (ctx->wifistations_ctx.fd
-				  && ctx->wifistations_ctx.fd == events[i].data.fd) {
+			} else if (ctx->wifistations_ctx.fd == events[i].data.fd) {
 				wifistations_handle_in(&ctx->wifistations_ctx);
 			}
 		}

--- a/src/wifistations.c
+++ b/src/wifistations.c
@@ -106,7 +106,12 @@ void wifistations_init(wifistations_ctx *ctx) {
 	int nl80211_id = genl_ctrl_resolve(ctx->nl_sock, "nl80211");
 	if (nl80211_id < 0) {
 		fprintf(stderr, "nl80211 not found.\n");
-		goto fail;
+		/* To resolve issue #29 we do not bail out, but return
+		 * without wifi socket instead.
+		 */
+		nl_socket_free(ctx->nl_sock);
+		ctx->nl_sock = NULL;
+		return;
 	}
 
 	/* MLME multicast group */

--- a/src/wifistations.c
+++ b/src/wifistations.c
@@ -106,9 +106,10 @@ void wifistations_init(wifistations_ctx *ctx) {
 	int nl80211_id = genl_ctrl_resolve(ctx->nl_sock, "nl80211");
 	if (nl80211_id < 0) {
 		fprintf(stderr, "nl80211 not found.\n");
-		/* To resolve issue #29 we do not bail out, but return
-		 * without wifi socket instead.
+		/* To resolve issue #29 we do not bail out, but return with an
+		 * invalid file descriptor and without a wifi socket instead.
 		 */
+		ctx->fd = -1;
 		nl_socket_free(ctx->nl_sock);
 		ctx->nl_sock = NULL;
 		return;


### PR DESCRIPTION
With this change the program just prints an error message when
there is no support for nl80211 in the kernel.

To work properly it is checked wether ctx->wifistations_ctx.fd is
initialized (!= 0) before polling at this file descriptor in
function loop().