### PR TITLE
clientmgr: clean up prefix_contains

### DIFF
--- a/src/arp.c
+++ b/src/arp.c
@@ -6,7 +6,6 @@
 #include <linux/netlink.h>
 #include <linux/if_packet.h>
 #include <linux/if_ether.h>
-#include <linux/if_arp.h>
 
 void arp_handle_in(arp_ctx *ctx, int fd) {
 	struct msghdr msghdr;
@@ -37,7 +36,7 @@ void arp_handle_in(arp_ctx *ctx, int fd) {
 	if (rc == -1)
 		return;
 
-	if (packet.op != htons(ARPOP_REPLY))
+	if (packet.op != htons(ARP_REPLY))
 		return;
 
 	uint8_t *mac = lladdr.sll_addr;
@@ -59,7 +58,7 @@ void arp_send_request(arp_ctx *ctx, const struct in6_addr *addr) {
 		.pr = htons(0x800),
 		.hdl = 6,
 		.prl = 4,
-		.op = htons(ARPOP_REQUEST)
+		.op = htons(ARP_REQUEST)
 	};
 
 	memcpy(&packet.sha, ctx->mac, 6);

--- a/src/arp.h
+++ b/src/arp.h
@@ -5,6 +5,9 @@
 #include <netinet/in.h>
 #include <linux/rtnetlink.h>
 
+#define ARP_REQUEST 1
+#define ARP_REPLY 2
+
 struct __attribute__((packed)) arp_packet {
 	uint16_t hd;
 	uint16_t pr;

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -51,18 +51,14 @@ struct in6_addr node_client_ip_from_mac(uint8_t mac[6]) {
 }
 
 bool prefix_contains(const struct prefix *prefix, struct in6_addr *addr) {
-	int plen = prefix->plen;
-
-	for (int i = 0; i < 16; i++) {
-		int mask = ~((1<<(8 - (plen > 8 ? 8 : plen))) - 1);
+	int mask=0xff;
+	for (int remaining_plen = prefix->plen, i=0;remaining_plen > 0; remaining_plen-= 8) {
+		if (remaining_plen < 8)
+			mask = 0xff & (0xff00 >>remaining_plen);
 
 		if ((addr->s6_addr[i] & mask) != prefix->prefix.s6_addr[i])
 			return false;
-
-		plen -= 8;
-
-		if (plen < 0)
-			plen = 0;
+		i++;
 	}
 	return true;
 }

--- a/src/routemgr.h
+++ b/src/routemgr.h
@@ -12,9 +12,7 @@
         ((struct rtattr*)(((char*)(r)) + NLMSG_ALIGN(sizeof(struct ndmsg))))
 #endif
 
-#ifndef RTA_ALIGNTO
 #define RTA_ALIGNTO     4
-#endif
 #define RTA_ALIGN(len) ( ((len)+RTA_ALIGNTO-1) & ~(RTA_ALIGNTO-1) )
 #define RTA_LENGTH(len) (RTA_ALIGN(sizeof(struct rtattr)) + (len))
 #define RTA_DATA(rta)   ((void*)(((char*)(rta)) + RTA_LENGTH(0)))

--- a/src/wifistations.c
+++ b/src/wifistations.c
@@ -20,7 +20,14 @@
 #include <netlink/msg.h>
 #include <netlink/attr.h>
 
-#include <linux/nl80211.h>
+#define NL80211_CMD_NEW_STATION 19
+#define NL80211_CMD_DEL_STATION 20
+#define NL80211_ATTR_IFINDEX 3
+#define NL80211_ATTR_MAC 6
+
+static int no_seq_check(struct nl_msg *msg, void *arg) {
+	return NL_OK;
+}
 
 void wifistations_handle_in(wifistations_ctx *ctx) {
 	nl_recvmsgs(ctx->nl_sock, ctx->cb);
@@ -72,15 +79,13 @@ void wifistations_init(wifistations_ctx *ctx) {
 		exit_error("Failed to allocate netlink socket.\n");
 
 	nl_socket_set_buffer_size(ctx->nl_sock, 8192, 8192);
-	/* no sequence checking for multicast messages */
-	nl_socket_disable_seq_check(ctx->nl_sock);
 
 	if (genl_connect(ctx->nl_sock)) {
 		fprintf(stderr, "Failed to connect to generic netlink.\n");
 		goto fail;
 	}
 
-	int nl80211_id = genl_ctrl_resolve(ctx->nl_sock, NL80211_GENL_NAME);
+	int nl80211_id = genl_ctrl_resolve(ctx->nl_sock, "nl80211");
 	if (nl80211_id < 0) {
 		fprintf(stderr, "nl80211 not found.\n");
 		/* To resolve issue #29 we do not bail out, but return with an
@@ -93,7 +98,7 @@ void wifistations_init(wifistations_ctx *ctx) {
 	}
 
 	/* MLME multicast group */
-	int mcid = nl_get_multicast_id(ctx->nl_sock, NL80211_GENL_NAME, NL80211_MULTICAST_GROUP_MLME);
+	int mcid = nl_get_multicast_id(ctx->nl_sock, "nl80211", "mlme");
 	if (mcid >= 0) {
 		int ret = nl_socket_add_membership(ctx->nl_sock, mcid);
 		if (ret)
@@ -105,6 +110,8 @@ void wifistations_init(wifistations_ctx *ctx) {
 	if (!ctx->cb)
 		exit_error("failed to allocate netlink callbacks\n");
 
+	/* no sequence checking for multicast messages */
+	nl_cb_set(ctx->cb, NL_CB_SEQ_CHECK, NL_CB_CUSTOM, no_seq_check, NULL);
 	nl_cb_set(ctx->cb, NL_CB_VALID, NL_CB_CUSTOM, wifistations_handle_event, ctx);
 
 	ctx->fd = nl_socket_get_fd(ctx->nl_sock);


### PR DESCRIPTION
This clarifies code in prefix_contains()