### PR TITLE
Only query intercom if the client is not detected locally

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,7 +4,9 @@ list(APPEND CMAKE_REQUIRED_DEFINITIONS '-D_GNU_SOURCE')
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${L3ROAMD_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-add_executable(l3roamd main.c socket.c config.c intercom.c arp.c ipmgr.c icmp6.c syscallwrappers.c routemgr.c prefix.c vector.c wifistations.c genl.c clientmgr.c taskqueue.c timespec.c)
+add_executable(l3roamd main.c socket.c config.c intercom.c arp.c ipmgr.c
+	icmp6.c syscallwrappers.c routemgr.c prefix.c vector.c wifistations.c
+	genl.c clientmgr.c taskqueue.c timespec.c util.c)
 
 target_link_libraries(l3roamd ${LIBNL_LIBRARIES} ${LIBNL_GENL_LIBRARIES})
 

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -375,6 +375,12 @@ bool clientmgr_is_ipv4(clientmgr_ctx *ctx, struct in6_addr *address) {
 	return prefix_contains(&ctx->v4prefix, address);
 }
 
+/** Remove an address from a client identified by its MAC.
+**/
+void clientmgr_remove_address(clientmgr_ctx *ctx, struct in6_addr *address, uint8_t *mac, unsigned int ifindex) {
+	printf("TODO: clientmgr_remove_address - currently not implemented\n");
+}
+
 /** Add a new address to a client identified by its MAC.
  */
 void clientmgr_add_address(clientmgr_ctx *ctx, struct in6_addr *address, uint8_t *mac, unsigned int ifindex) {

--- a/src/clientmgr.h
+++ b/src/clientmgr.h
@@ -56,4 +56,5 @@ void clientmgr_purge_clients(clientmgr_ctx *ctx);
 void clientmgr_delete_client(clientmgr_ctx *ctx, const uint8_t mac[6]);
 void client_ip_set_state(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip, enum ip_state state);
 struct client *get_client(clientmgr_ctx *ctx, const uint8_t mac[6]);
+bool clientmgr_is_known_address(clientmgr_ctx *ctx, struct in6_addr *address);
 void mac_addr_n2a(char *mac_addr, unsigned char *arg);

--- a/src/clientmgr.h
+++ b/src/clientmgr.h
@@ -48,6 +48,7 @@ struct client_task {
 bool clientmgr_valid_address(clientmgr_ctx *ctx, struct in6_addr *ip);
 bool clientmgr_is_ipv4(clientmgr_ctx *ctx, struct in6_addr *ip);
 void clientmgr_add_address(clientmgr_ctx *ctx, struct in6_addr *address, uint8_t *mac, unsigned int ifindex);
+void clientmgr_remove_address(clientmgr_ctx *ctx, struct in6_addr *address, uint8_t *mac, unsigned int ifindex);
 void clientmgr_notify_mac(clientmgr_ctx *ctx, uint8_t *mac, unsigned int ifindex);
 void clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender, uint8_t mac[6]);
 void clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client, bool relinquished);

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -123,6 +123,7 @@ void intercom_seek(intercom_ctx *ctx, const struct in6_addr *address) {
 	intercom_recently_seen_add(ctx, &packet.hdr);
 
 	intercom_send_packet(ctx, (uint8_t*)&packet, sizeof(packet));
+
 }
 
 bool intercom_send_packet_unicast(intercom_ctx *ctx, const struct in6_addr *recipient, uint8_t *packet, ssize_t packet_len) {

--- a/src/ipmgr.h
+++ b/src/ipmgr.h
@@ -30,7 +30,7 @@
 
 #include <stdint.h>
 #include <netinet/in.h>
-
+#include "intercom.h"
 #define IPCHECK_INTERVAL 2
 #define PACKET_TIMEOUT 2
 #define SEEK_TIMEOUT 10
@@ -41,10 +41,16 @@ struct packet {
 	uint8_t *data;
 };
 
+enum tasktype {
+	TASK_CHECK =0,
+	TASK_SEEK
+};
+
 struct entry {
 	struct in6_addr address;
 	struct timespec timestamp;
 	taskqueue_t *check_task;
+	enum tasktype type;
 	VECTOR(struct packet*) packets;
 };
 

--- a/src/l3roamd.h
+++ b/src/l3roamd.h
@@ -29,6 +29,7 @@ struct l3ctx {
 	arp_ctx arp_ctx;
 	routemgr_ctx routemgr_ctx;
 	socket_ctx socket_ctx;
+	bool debug;
 };
 
 extern l3ctx_t l3ctx;

--- a/src/main.c
+++ b/src/main.c
@@ -224,10 +224,10 @@ int main(int argc, char *argv[]) {
 	bool a_initialized=false;
 	bool p_initialized=false;
 
-
+	l3ctx.debug = false;
 
 	int c;
-	while ((c = getopt(argc, argv, "ha:b:p:i:m:t:c:4:n:s:")) != -1)
+	while ((c = getopt(argc, argv, "dha:b:p:i:m:t:c:4:n:s:d")) != -1)
 		switch (c) {
 			case 'b':
 				free(l3ctx.routemgr_ctx.client_bridge);
@@ -279,6 +279,9 @@ int main(int argc, char *argv[]) {
 				break;
 			case 's':
 				socketpath = optarg;
+				break;
+			case 'd':
+				l3ctx.debug = true;
 				break;
 			case '4':
 				if (!parse_prefix(&l3ctx.clientmgr_ctx.v4prefix, optarg))

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,15 @@
+
+
+#include "util.h"
+#include <arpa/inet.h>
+#include <stdio.h>
+
+// TODO: where should we put this?
+/* print a human-readable representation of an in6_addr struct to stdout
+** */
+void print_ip(const struct in6_addr *addr) {
+	char a1[INET6_ADDRSTRLEN+1];
+	inet_ntop(AF_INET6, addr, a1, INET6_ADDRSTRLEN);
+	printf("%s", a1);
+}
+

--- a/src/util.h
+++ b/src/util.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <netinet/in.h>
+
+void print_ip(const struct in6_addr *addr);
+


### PR DESCRIPTION
This fixes #23.

When a packet to an unknown ipv6 destination address is received, first locally connected clients are queried via NS. After a while intercom will be queried if a local client with that IP is not available.