### PR TITLE
add version information

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,3 +13,24 @@ target_link_libraries(l3roamd ${LIBNL_LIBRARIES} ${LIBNL_GENL_LIBRARIES})
 set_target_properties(l3roamd PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wall" LINK_FLAGS "")
 
 install(TARGETS l3roamd RUNTIME DESTINATION bin)
+
+# Get the current working branch
+execute_process(
+  COMMAND git rev-parse --abbrev-ref HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_BRANCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Get the latest abbreviated commit hash of the working branch
+execute_process(
+  COMMAND git log -1 --format=%h
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+configure_file(
+  ${CMAKE_SOURCE_DIR}/src/version.h.in
+  ${CMAKE_BINARY_DIR}/src/version.h
+)

--- a/src/main.c
+++ b/src/main.c
@@ -25,6 +25,7 @@
 
 // TODO EPOLLOUT beim schreiben auf den tunfd
 
+#include "version.h"
 #include "vector.h"
 #include "ipmgr.h"
 #include "error.h"
@@ -154,6 +155,7 @@ void usage() {
 	puts("  -m <meshif>        mesh interface. may be specified multiple times");
 	puts("  -t <export table>  export routes to this table");
 	puts("  -4 <prefix>        IPv4 translation prefix");
+        puts("  -V                 show version information");
 	puts("  -h                 this help\n\n");
 	puts("The socket will accept the following commands:");
 	puts("get_clients          The daemon will reply with a json structure, currently providing client count.");
@@ -226,8 +228,15 @@ int main(int argc, char *argv[]) {
 	l3ctx.debug = false;
 
 	int c;
-	while ((c = getopt(argc, argv, "dha:b:p:i:m:t:c:4:n:s:d")) != -1)
+	while ((c = getopt(argc, argv, "dha:b:p:i:m:t:c:4:n:s:d:V")) != -1)
 		switch (c) {
+                        case 'V':
+                                printf("l3roamd %s\n", SOURCE_VERSION);
+#if defined(GIT_BRANCH) && defined(GIT_COMMIT_HASH)
+                                printf("branch: %s\n", GIT_BRANCH);
+                                printf("commit: %s\n", GIT_COMMIT_HASH);
+#endif
+                                exit(EXIT_SUCCESS);
 			case 'b':
 				free(l3ctx.routemgr_ctx.client_bridge);
 				l3ctx.routemgr_ctx.client_bridge = strdupa(optarg);

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,33 @@
+/*
+   Copyright (c) 2015, Nils Schneider <nils@nilsschneider.net>
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   */
+
+#ifndef VERSION_H
+#define VERSION_H
+
+#define SOURCE_VERSION "0.0.1"
+#define GIT_BRANCH "@GIT_BRANCH@"
+#define GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
+
+#endif


### PR DESCRIPTION
As requested in [#60](https://github.com/freifunk-ffm/ToDo-Liste/issues/60), adding a version switch.

Static version is in src/version.h.in. When compiled from git, branch and commit hash will also be displayed.