### PR TITLE
Allow roaming during the first 4.5s after connecting to the network

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -35,7 +35,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     80
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4

--- a/src/arp.c
+++ b/src/arp.c
@@ -37,8 +37,7 @@ void arp_handle_in(arp_ctx *ctx, int fd) {
 	if (packet.op != htons(ARP_REPLY))
 		return;
 
-	if (memcmp(packet.spa, "\x00\x00\x00\x00", 4) ==
-	    0)  // IP is 0.0.0.0 - not sensible to add that.
+	if (memcmp(packet.spa, "\x00\x00\x00\x00", 4) == 0)  // IP is 0.0.0.0 - not sensible to add that.
 		return;
 
 	uint8_t *mac = lladdr.sll_addr;
@@ -49,20 +48,14 @@ void arp_handle_in(arp_ctx *ctx, int fd) {
 
 	char str[INET6_ADDRSTRLEN];
 	inet_ntop(AF_INET6, &address, str, INET6_ADDRSTRLEN);
-	log_verbose(
-	    "ARP Response from %s (MAC %02x:%02x:%02x:%02x:%02x:%02x)\n", str,
-	    mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+	log_verbose("ARP Response from %s (MAC %02x:%02x:%02x:%02x:%02x:%02x)\n", str, mac[0], mac[1], mac[2], mac[3],
+		    mac[4], mac[5]);
 
-	clientmgr_add_address(CTX(clientmgr), &address, packet.sha,
-			      ctx->ifindex);
+	clientmgr_add_address(CTX(clientmgr), &address, packet.sha, ctx->ifindex);
 }
 
 void arp_send_request(arp_ctx *ctx, const struct in6_addr *addr) {
-	struct arp_packet packet = {.hd = htons(1),
-				    .pr = htons(0x800),
-				    .hdl = 6,
-				    .prl = 4,
-				    .op = htons(ARP_REQUEST)};
+	struct arp_packet packet = {.hd = htons(1), .pr = htons(0x800), .hdl = 6, .prl = 4, .op = htons(ARP_REQUEST)};
 
 	memcpy(&packet.sha, ctx->mac, 6);
 	memcpy(&packet.spa, "\x00\x00\x00\x00", 4);
@@ -72,16 +65,12 @@ void arp_send_request(arp_ctx *ctx, const struct in6_addr *addr) {
 	log_verbose("Send ARP to %s\n", print_ip(addr));
 
 	struct sockaddr_ll dst = {
-	    .sll_ifindex = ctx->ifindex,
-	    .sll_protocol = htons(ETH_P_ARP),
-	    .sll_family = PF_PACKET,
-	    .sll_halen = 6,
+	    .sll_ifindex = ctx->ifindex, .sll_protocol = htons(ETH_P_ARP), .sll_family = PF_PACKET, .sll_halen = 6,
 	};
 
 	memcpy(&dst.sll_addr, "\xff\xff\xff\xff\xff\xff", 6);
 
-	sendto(ctx->fd, &packet, sizeof(packet), 0, (struct sockaddr *)&dst,
-	       sizeof(dst));
+	sendto(ctx->fd, &packet, sizeof(packet), 0, (struct sockaddr *)&dst, sizeof(dst));
 }
 
 void arp_init(arp_ctx *ctx) {
@@ -115,12 +104,10 @@ void arp_setup_interface(arp_ctx *ctx) {
 	}
 
 	ctx->ifindex = req.ifr_ifindex;
-	log_verbose("initialized arp-fd (%i) on interface with index: %i\n",
-		    ctx->fd, ctx->ifindex);
+	log_verbose("initialized arp-fd (%i) on interface with index: %i\n", ctx->fd, ctx->ifindex);
 }
 
-void arp_interface_changed(arp_ctx *ctx, int type,
-			   const struct ifinfomsg *msg) {
+void arp_interface_changed(arp_ctx *ctx, int type, const struct ifinfomsg *msg) {
 	char ifname[IFNAMSIZ];
 
 	if (if_indextoname(msg->ifi_index, ifname) == NULL)
@@ -136,9 +123,7 @@ void arp_interface_changed(arp_ctx *ctx, int type,
 		case RTM_SETLINK:
 			log_verbose("arp interface changed - NEW or SET\n");
 			if (ctx->ifindex != msg->ifi_index) {
-				log_verbose(
-				    "re-initializing arp interface %s\n",
-				    ifname);
+				log_verbose("re-initializing arp interface %s\n", ifname);
 				arp_setup_interface(ctx);
 			}
 			break;

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -87,21 +87,14 @@ void print_client(struct client *client) {
 
 		switch (addr->state) {
 			case IP_INACTIVE:
-				log_verbose("  %s  %s\n",
-					    state_str(addr->state),
-					    print_ip(&addr->addr));
+				log_verbose("  %s  %s\n", state_str(addr->state), print_ip(&addr->addr));
 				break;
 			case IP_ACTIVE:
-				log_verbose("  %s    %s (%ld.%.9ld)\n",
-					    state_str(addr->state),
-					    print_ip(&addr->addr),
-					    addr->timestamp.tv_sec,
-					    addr->timestamp.tv_nsec);
+				log_verbose("  %s    %s (%ld.%.9ld)\n", state_str(addr->state), print_ip(&addr->addr),
+					    addr->timestamp.tv_sec, addr->timestamp.tv_nsec);
 				break;
 			case IP_TENTATIVE:
-				log_verbose("  %s %s (tries left: %d)\n",
-					    state_str(addr->state),
-					    print_ip(&addr->addr),
+				log_verbose("  %s %s (tries left: %d)\n", state_str(addr->state), print_ip(&addr->addr),
 					    addr->tentative_retries_left);
 				break;
 			default:
@@ -128,8 +121,7 @@ bool client_is_active(const struct client *client) {
 		struct client_ip *ip = &VECTOR_INDEX(client->addresses, i);
 
 		if (ip_is_active(ip)) {
-			log_debug("client [%s] is active on ip %s\n",
-				  print_mac(client->mac), print_ip(&ip->addr));
+			log_debug("client [%s] is active on ip %s\n", print_mac(client->mac), print_ip(&ip->addr));
 			return true;
 		}
 	}
@@ -142,15 +134,12 @@ int bind_to_address(struct in6_addr *address) {
 	rtnl_add_address(&l3ctx.routemgr_ctx, address);
 
 	struct sockaddr_in6 server_addr = {
-	    .sin6_family = AF_INET6,
-	    .sin6_port = htons(INTERCOM_PORT),
-	    .sin6_addr = *address,
+	    .sin6_family = AF_INET6, .sin6_port = htons(INTERCOM_PORT), .sin6_addr = *address,
 	};
 
 	fd = socket(PF_INET6, SOCK_DGRAM | SOCK_NONBLOCK, 0);
 	if (fd < 0) {
-		perror(
-		    "creating socket for listening on node-client-IP failed:");
+		perror("creating socket for listening on node-client-IP failed:");
 		exit_error("creating socket for intercom on node-client-IP");
 	}
 
@@ -164,8 +153,7 @@ int bind_to_address(struct in6_addr *address) {
 		exit_error("setsockopt: IP_FREEBIND");
 	}
 
-	if (bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) <
-	    0) {
+	if (bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
 		fprintf(stderr,
 			"Could not bind to socket %i on special ip for "
 			"address: %s. exiting.\n",
@@ -181,7 +169,7 @@ int bind_to_address(struct in6_addr *address) {
 */
 void add_special_ip(clientmgr_ctx *ctx, struct client *client) {
 	if (client == NULL)  // this can happen if the client was removed before
-			     // the claim cycle was finished
+		// the claim cycle was finished
 		return;
 
 	if (client->node_ip_initialized) {
@@ -192,8 +180,7 @@ void add_special_ip(clientmgr_ctx *ctx, struct client *client) {
 		return;
 	}
 
-	struct in6_addr address =
-	    mac2ipv6(client->mac, &ctx->node_client_prefix);
+	struct in6_addr address = mac2ipv6(client->mac, &ctx->node_client_prefix);
 	client->fd = bind_to_address(&address);
 
 	client->node_ip_initialized = true;
@@ -217,8 +204,7 @@ void close_client_fd(int *fd) {
 /** Removes the special node client IP address.
 */
 void remove_special_ip(clientmgr_ctx *ctx, struct client *client) {
-	struct in6_addr address =
-	    mac2ipv6(client->mac, &ctx->node_client_prefix);
+	struct in6_addr address = mac2ipv6(client->mac, &ctx->node_client_prefix);
 	printf("Removing special address: %s\n", print_ip(&address));
 	close_client_fd(&client->fd);
 	routemgr_remove_route(CTX(routemgr), ctx->export_table, &address, 128);
@@ -230,8 +216,7 @@ void remove_special_ip(clientmgr_ctx *ctx, struct client *client) {
 /** Given an IP address returns the client-object of a client.
   Returns NULL if no object is found.
   */
-struct client_ip *get_client_ip(struct client *client,
-				const struct in6_addr *address) {
+struct client_ip *get_client_ip(struct client *client, const struct in6_addr *address) {
 	for (int i = VECTOR_LEN(client->addresses) - 1; i >= 0; i--) {
 		struct client_ip *e = &VECTOR_INDEX(client->addresses, i);
 
@@ -245,15 +230,12 @@ struct client_ip *get_client_ip(struct client *client,
 /** Removes an IP address from a client. Safe to call if the IP is not
   currently present in the clients list.
   */
-void delete_client_ip(struct client *client, const struct in6_addr *address,
-		      bool cleanup) {
+void delete_client_ip(struct client *client, const struct in6_addr *address, bool cleanup) {
 	for (int i = VECTOR_LEN(client->addresses) - 1; i >= 0; i--) {
 		struct client_ip *e = &VECTOR_INDEX(client->addresses, i);
 
 		if (memcmp(address, &e->addr, sizeof(struct in6_addr)) == 0) {
-			client_ip_set_state(&l3ctx.clientmgr_ctx, client,
-					    get_client_ip(client, address),
-					    IP_INACTIVE);
+			client_ip_set_state(&l3ctx.clientmgr_ctx, client, get_client_ip(client, address), IP_INACTIVE);
 			if (cleanup)
 				VECTOR_DELETE(client->addresses, i);
 		}
@@ -270,51 +252,40 @@ void delete_client_ip(struct client *client, const struct in6_addr *address,
 
 /** Adds a route and a neighbour entry
 */
-static void client_add_route(clientmgr_ctx *ctx, struct client *client,
-			     struct client_ip *ip) {
+static void client_add_route(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip) {
 	log_verbose("adding neighbour and route for %s", print_ip(&ip->addr));
 	if (address_is_ipv4(&ip->addr)) {
 		log_verbose(" (IPv4)\n");
 
 		struct in_addr ip4 = extractv4_v6(&ip->addr);
-		log_verbose("Adding neighbor and route for IP: %s\n",
-			    print_ip4(&ip4));
-		routemgr_insert_neighbor4(&l3ctx.routemgr_ctx, client->ifindex,
-					  &ip4, client->mac);
+		log_verbose("Adding neighbor and route for IP: %s\n", print_ip4(&ip4));
+		routemgr_insert_neighbor4(&l3ctx.routemgr_ctx, client->ifindex, &ip4, client->mac);
 
 		// 		routemgr_insert_neighbor(&l3ctx.routemgr_ctx,
 		// client->ifindex, &ip->addr, client->mac);
 		//		routemgr_insert_route(CTX(routemgr),
 		// ctx->export_table, ctx->nat46ifindex, &ip->addr, 128);
-		routemgr_insert_route4(CTX(routemgr), ctx->export_table,
-				       client->ifindex, &ip4, 32);
+		routemgr_insert_route4(CTX(routemgr), ctx->export_table, client->ifindex, &ip4, 32);
 	} else {
 		log_verbose(" (IPv6)\n");
-		routemgr_insert_neighbor(&l3ctx.routemgr_ctx, client->ifindex,
-					 &ip->addr, client->mac);
-		routemgr_insert_route(CTX(routemgr), ctx->export_table,
-				      client->ifindex, &ip->addr, 128);
+		routemgr_insert_neighbor(&l3ctx.routemgr_ctx, client->ifindex, &ip->addr, client->mac);
+		routemgr_insert_route(CTX(routemgr), ctx->export_table, client->ifindex, &ip->addr, 128);
 	}
 }
 
 /** Remove a route.
 */
-static void client_remove_route(clientmgr_ctx *ctx, struct client *client,
-				struct client_ip *ip) {
+static void client_remove_route(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip) {
 	if (address_is_ipv4(&ip->addr)) {
 		struct in_addr ip4 = extractv4_v6(&ip->addr);
 
 		//		routemgr_remove_route(CTX(routemgr),
 		// ctx->export_table, &ip->addr, 128);
-		routemgr_remove_route4(CTX(routemgr), ctx->export_table, &ip4,
-				       32);
-		routemgr_remove_neighbor4(CTX(routemgr), client->ifindex, &ip4,
-					  client->mac);
+		routemgr_remove_route4(CTX(routemgr), ctx->export_table, &ip4, 32);
+		routemgr_remove_neighbor4(CTX(routemgr), client->ifindex, &ip4, client->mac);
 	} else {
-		routemgr_remove_route(CTX(routemgr), ctx->export_table,
-				      &ip->addr, 128);
-		routemgr_remove_neighbor(CTX(routemgr), client->ifindex,
-					 &ip->addr, client->mac);
+		routemgr_remove_route(CTX(routemgr), ctx->export_table, &ip->addr, 128);
+		routemgr_remove_neighbor(CTX(routemgr), client->ifindex, &ip->addr, client->mac);
 	}
 }
 
@@ -323,8 +294,7 @@ static void client_remove_route(clientmgr_ctx *ctx, struct client *client,
   */
 struct client *findinvector(void *_vector, const uint8_t mac[ETH_ALEN]) {
 	VECTOR(struct client) *vector = _vector;
-	for (int _vector_index = VECTOR_LEN(*vector) - 1; _vector_index >= 0;
-	     _vector_index--) {
+	for (int _vector_index = VECTOR_LEN(*vector) - 1; _vector_index >= 0; _vector_index--) {
 		struct client *e = &VECTOR_INDEX(*vector, _vector_index);
 
 		if (memcmp(mac, e->mac, sizeof(uint8_t) * 6) == 0)
@@ -344,10 +314,8 @@ struct client *get_client_old(const uint8_t mac[ETH_ALEN]) {
 
 /** Given an ip-address, this returns true if there is a local client connected
  * having this IP-address and false otherwise
-*/
-bool clientmgr_is_known_address(clientmgr_ctx *ctx,
-				const struct in6_addr *address,
-				struct client **client) {
+ */
+bool clientmgr_is_known_address(clientmgr_ctx *ctx, const struct in6_addr *address, struct client **client) {
 	// TODO: we probably should make this more efficient for large lists of
 	// clients and IP addresses at one point.
 	for (int i = VECTOR_LEN(ctx->clients) - 1; i >= 0; i--) {
@@ -355,10 +323,8 @@ bool clientmgr_is_known_address(clientmgr_ctx *ctx,
 
 		for (int j = VECTOR_LEN(c->addresses) - 1; j >= 0; j--) {
 			struct client_ip *a = &VECTOR_INDEX(c->addresses, j);
-			if (!memcmp(address, &a->addr,
-				    sizeof(struct in6_addr))) {
-				log_debug("%s is attached to local client %s\n",
-					  print_ip(address), print_mac(c->mac));
+			if (!memcmp(address, &a->addr, sizeof(struct in6_addr))) {
+				log_debug("%s is attached to local client %s\n", print_ip(address), print_mac(c->mac));
 
 				if (client) {
 					*client = c;
@@ -368,14 +334,12 @@ bool clientmgr_is_known_address(clientmgr_ctx *ctx,
 		}
 	}
 
-	log_debug("%s is not assigned to any of the local clients\n",
-		  print_ip(address));
+	log_debug("%s is not assigned to any of the local clients\n", print_ip(address));
 
 	return false;
 }
 
-struct client *create_client(client_vector *vector, const uint8_t mac[ETH_ALEN],
-			     const unsigned int ifindex) {
+struct client *create_client(client_vector *vector, const uint8_t mac[ETH_ALEN], const unsigned int ifindex) {
 	struct client _client = {};
 	memcpy(_client.mac, mac, sizeof(uint8_t) * 6);
 	_client.ifindex = ifindex;
@@ -391,13 +355,11 @@ struct client *create_client(client_vector *vector, const uint8_t mac[ETH_ALEN],
 
 /** Get a client or create a new, empty one.
 */
-struct client *get_or_create_client(const uint8_t mac[ETH_ALEN],
-				    unsigned int ifindex) {
+struct client *get_or_create_client(const uint8_t mac[ETH_ALEN], unsigned int ifindex) {
 	struct client *client = get_client(mac);
 
 	if (client == NULL) {
-		client =
-		    create_client(&l3ctx.clientmgr_ctx.clients, mac, ifindex);
+		client = create_client(&l3ctx.clientmgr_ctx.clients, mac, ifindex);
 	}
 
 	return client;
@@ -421,34 +383,30 @@ void client_copy_to_old(struct client *client) {
 	then.tv_sec = now.tv_sec + OLDCLIENTS_KEEP_SECONDS;
 	then.tv_nsec = now.tv_nsec;
 
-	struct client *_client = create_client(&l3ctx.clientmgr_ctx.oldclients,
-					       client->mac, client->ifindex);
+	struct client *_client = create_client(&l3ctx.clientmgr_ctx.oldclients, client->mac, client->ifindex);
 	_client->timeout = then;
 	_client->platprefix = client->platprefix;
 
 	for (int i = VECTOR_LEN(client->addresses) - 1; i >= 0; i--) {
-		VECTOR_ADD(_client->addresses,
-			   VECTOR_INDEX(client->addresses, i));
+		VECTOR_ADD(_client->addresses, VECTOR_INDEX(client->addresses, i));
 	}
 
 	if (l3ctx.debug) {
-		log_debug("copied client[%s] to old-queue:\n",
-			  print_mac(client->mac));
+		log_debug("copied client[%s] to old-queue:\n", print_mac(client->mac));
 		print_client(_client);
 	}
 }
 
 /** This will set all IP addresses of the client to IP_INACTIVE and remove the
  * special IP & route
-*/
+ */
 void client_deactivate(struct client *client) {
 	struct client *_client = get_client(client->mac);
 	client_copy_to_old(_client);
 	for (int i = VECTOR_LEN(_client->addresses) - 1; i >= 0; i--) {
 		struct client_ip *ip = &VECTOR_INDEX(_client->addresses, i);
 		if (ip)
-			client_ip_set_state(&l3ctx.clientmgr_ctx, _client, ip,
-					    IP_INACTIVE);
+			client_ip_set_state(&l3ctx.clientmgr_ctx, _client, ip, IP_INACTIVE);
 	}
 	VECTOR_FREE(_client->addresses);
 	remove_special_ip(&l3ctx.clientmgr_ctx, _client);
@@ -461,8 +419,7 @@ void clientmgr_delete_client(clientmgr_ctx *ctx, uint8_t mac[ETH_ALEN]) {
 	struct client *client = get_client(mac);
 
 	if (client == NULL) {
-		log_debug("Client [%s] unknown: cannot delete\n",
-			  print_mac(mac));
+		log_debug("Client [%s] unknown: cannot delete\n", print_mac(mac));
 		return;
 	}
 
@@ -478,18 +435,15 @@ void clientmgr_delete_client(clientmgr_ctx *ctx, uint8_t mac[ETH_ALEN]) {
 
 	if (VECTOR_LEN(client->addresses) > 0) {
 		for (int i = VECTOR_LEN(client->addresses) - 1; i >= 0; i--) {
-			struct client_ip *e =
-			    &VECTOR_INDEX(client->addresses, i);
-			client_ip_set_state(CTX(clientmgr), client, e,
-					    IP_INACTIVE);
+			struct client_ip *e = &VECTOR_INDEX(client->addresses, i);
+			client_ip_set_state(CTX(clientmgr), client, e, IP_INACTIVE);
 			delete_client_ip(client, &e->addr, true);
 		}
 	}
 	VECTOR_FREE(client->addresses);
 
 	for (int i = VECTOR_LEN(ctx->clients) - 1; i >= 0; i--) {
-		if (memcmp(&(VECTOR_INDEX(ctx->clients, i).mac), mac,
-			   sizeof(uint8_t) * 6) == 0) {
+		if (memcmp(&(VECTOR_INDEX(ctx->clients, i).mac), mac, sizeof(uint8_t) * 6) == 0) {
 			VECTOR_DELETE(ctx->clients, i);
 			break;
 		}
@@ -514,8 +468,7 @@ const char *state_str(enum ip_state state) {
 TODO: we really should update the neighbour-table here too instead of
 clientmgr_add_client et al.
 */
-void client_ip_set_state(clientmgr_ctx *ctx, struct client *client,
-			 struct client_ip *ip, enum ip_state state) {
+void client_ip_set_state(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip, enum ip_state state) {
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	bool nop = false;
@@ -532,8 +485,7 @@ void client_ip_set_state(clientmgr_ctx *ctx, struct client *client,
 					break;
 				case IP_TENTATIVE:
 					ip->timestamp = now;
-					ipmgr_seek_address(&l3ctx.ipmgr_ctx,
-							   &ip->addr);
+					ipmgr_seek_address(&l3ctx.ipmgr_ctx, &ip->addr);
 					break;
 			}
 			break;
@@ -549,8 +501,7 @@ void client_ip_set_state(clientmgr_ctx *ctx, struct client *client,
 					break;
 				case IP_TENTATIVE:
 					ip->timestamp = now;
-					ipmgr_seek_address(&l3ctx.ipmgr_ctx,
-							   &ip->addr);
+					ipmgr_seek_address(&l3ctx.ipmgr_ctx, &ip->addr);
 					break;
 			}
 			break;
@@ -573,16 +524,14 @@ void client_ip_set_state(clientmgr_ctx *ctx, struct client *client,
 	}
 
 	if (!nop || l3ctx.debug)
-		log_error("%s changes from %s to %s\n", print_ip(&ip->addr),
-			  state_str(ip->state), state_str(state));
+		log_error("%s changes from %s to %s\n", print_ip(&ip->addr), state_str(ip->state), state_str(state));
 
 	ip->state = state;
 }
 
 /** Check whether an IP address is contained in a client prefix.
 */
-bool clientmgr_valid_address(clientmgr_ctx *ctx,
-			     const struct in6_addr *address) {
+bool clientmgr_valid_address(clientmgr_ctx *ctx, const struct in6_addr *address) {
 	for (int i = VECTOR_LEN(ctx->prefixes) - 1; i >= 0; i--) {
 		struct prefix *_prefix = &VECTOR_INDEX(ctx->prefixes, i);
 		if (prefix_contains(_prefix, address))
@@ -594,10 +543,8 @@ bool clientmgr_valid_address(clientmgr_ctx *ctx,
 
 /** Remove an address from a client identified by its MAC.
 **/
-void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client,
-			      struct in6_addr *address) {
-	log_debug("clientmgr_remove_address: %s is running for client %s",
-		  print_ip(address), print_mac(client->mac));
+void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client, struct in6_addr *address) {
+	log_debug("clientmgr_remove_address: %s is running for client %s", print_ip(address), print_mac(client->mac));
 
 	if (client) {
 		delete_client_ip(client, address, true);
@@ -614,8 +561,8 @@ void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client,
 
 /** Add a new address to a client identified by its MAC.
 */
-void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address,
-			   const uint8_t *mac, const unsigned int ifindex) {
+void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address, const uint8_t *mac,
+			   const unsigned int ifindex) {
 	if (!clientmgr_valid_address(ctx, address)) {
 		log_debug(
 		    "address is not within a client-prefix and not an "
@@ -636,7 +583,7 @@ void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address,
 	struct client *client = get_or_create_client(mac, ifindex);
 	struct client_ip *ip = get_client_ip(client, address);
 	client->ifindex = ifindex;  // client might have roamed to different
-				    // interface on the same node
+	// interface on the same node
 
 	bool ip_is_new = ip == NULL;
 
@@ -649,39 +596,33 @@ void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address,
 	client_ip_set_state(ctx, client, ip, IP_ACTIVE);
 
 	if (!client->claimed) {
-		struct in6_addr address =
-		    mac2ipv6(client->mac, &ctx->node_client_prefix);
-		intercom_claim(CTX(intercom), &address,
-			       client);  // this will set the special_ip after
-					 // the claiming cycle
+		struct in6_addr address = mac2ipv6(client->mac, &ctx->node_client_prefix);
+		intercom_claim(CTX(intercom), &address, client);  // this will set the special_ip after
+								  // the claiming cycle
 	}
 }
 
 /** Notify the client manager about a new MAC (e.g. a new wifi client).
 */
-void clientmgr_notify_mac(clientmgr_ctx *ctx, uint8_t *mac,
-			  unsigned int ifindex) {
+void clientmgr_notify_mac(clientmgr_ctx *ctx, uint8_t *mac, unsigned int ifindex) {
 	if (memcmp(mac, "\x00\x00\x00\x00\x00\x00", 6) == 0)
 		return;
 
 	struct client *client = get_or_create_client(mac, ifindex);
 
 	if (client->claimed || client_is_active(client)) {
-		log_debug("client[%s] was detected earlier, not re-adding\n",
-			  print_mac(client->mac));
+		log_debug("client[%s] was detected earlier, not re-adding\n", print_mac(client->mac));
 		return;
 	}
 
 	char ifname[IFNAMSIZ];
 	if_indextoname(ifindex, ifname);
 
-	log_verbose("\033[34mnew client %s on %s\033[0m\n",
-		    print_mac(client->mac), ifname);
+	log_verbose("\033[34mnew client %s on %s\033[0m\n", print_mac(client->mac), ifname);
 
 	client->ifindex = ifindex;
 
-	struct in6_addr address =
-	    mac2ipv6(client->mac, &ctx->node_client_prefix);
+	struct in6_addr address = mac2ipv6(client->mac, &ctx->node_client_prefix);
 
 	if (!client->claimed)
 		intercom_claim(CTX(intercom), &address, client);
@@ -713,8 +654,7 @@ void purge_oldclientlist_from_old_clients() {
 
 	log_debug("Purging old clients\n");
 
-	for (int i = VECTOR_LEN(l3ctx.clientmgr_ctx.oldclients) - 1; i >= 0;
-	     i--) {
+	for (int i = VECTOR_LEN(l3ctx.clientmgr_ctx.oldclients) - 1; i >= 0; i--) {
 		_client = &VECTOR_INDEX(l3ctx.clientmgr_ctx.oldclients, i);
 
 		if (timespec_cmp(_client->timeout, now) <= 0) {
@@ -732,15 +672,13 @@ void purge_oldclientlist_from_old_clients() {
 void purge_oldclients_task() {
 	purge_oldclientlist_from_old_clients();
 
-	post_task(&l3ctx.taskqueue_ctx, OLDCLIENTS_KEEP_SECONDS, 0,
-		  purge_oldclients_task, NULL, NULL);
+	post_task(&l3ctx.taskqueue_ctx, OLDCLIENTS_KEEP_SECONDS, 0, purge_oldclients_task, NULL, NULL);
 }
 
 /** Handle claim (info request). return true if we acted on a local client,
  * false otherwise
-*/
-bool clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender,
-			    uint8_t mac[ETH_ALEN]) {
+ */
+bool clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender, uint8_t mac[ETH_ALEN]) {
 	bool old = false;
 	struct client *client = get_client(mac);
 	if (client == NULL) {
@@ -762,9 +700,7 @@ bool clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender,
 	intercom_info(CTX(intercom), sender, client, true);
 
 	if (!old) {
-		printf(
-		    "Dropping client %s in response to claim from sender %s\n",
-		    print_mac(mac), print_ip(sender));
+		printf("Dropping client %s in response to claim from sender %s\n", print_mac(mac), print_ip(sender));
 		clientmgr_delete_client(ctx, client->mac);
 	}
 	return true;
@@ -772,7 +708,7 @@ bool clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender,
 
 /** Handle incoming client info. return true if we acted on local client, false
  * otherwise
-*/
+ */
 bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client) {
 	struct client *client = get_client(foreign_client->mac);
 	if (client == NULL) {
@@ -784,24 +720,18 @@ bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client) {
 	}
 
 	if (l3ctx.debug) {
-		log_verbose(
-		    "handling info message in clientmgr_handle_info() for "
-		    "foreign_client ");
+		log_debug("handling info message in clientmgr_handle_info() for foreign_client ");
 		print_client(foreign_client);
 	}
 
 	for (int i = VECTOR_LEN(foreign_client->addresses) - 1; i >= 0; i--) {
-		struct client_ip *foreign_ip =
-		    &VECTOR_INDEX(foreign_client->addresses, i);
-		bool is_client_ip_known =
-		    get_client_ip(client, &foreign_ip->addr);
+		struct client_ip *foreign_ip = &VECTOR_INDEX(foreign_client->addresses, i);
+		bool is_client_ip_known = get_client_ip(client, &foreign_ip->addr);
 
 		if (!is_client_ip_known)
 			continue;
 
-		clientmgr_add_address(ctx, &foreign_ip->addr,
-				      foreign_client->mac,
-				      l3ctx.icmp6_ctx.ifindex);
+		clientmgr_add_address(ctx, &foreign_ip->addr, foreign_client->mac, l3ctx.icmp6_ctx.ifindex);
 	}
 
 	add_special_ip(ctx, client);
@@ -814,10 +744,7 @@ bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client) {
 
 void clientmgr_init() {
 	VECTOR_INIT((&l3ctx.clientmgr_ctx)->clients);
-	post_task(&l3ctx.taskqueue_ctx, OLDCLIENTS_KEEP_SECONDS, 0,
-		  purge_oldclients_task, NULL, NULL);
+	post_task(&l3ctx.taskqueue_ctx, OLDCLIENTS_KEEP_SECONDS, 0, purge_oldclients_task, NULL, NULL);
 }
 
-int client_compare_by_mac(const struct client *a, const struct client *b) {
-	return memcmp(&a->mac, &b->mac, ETH_ALEN);
-}
+int client_compare_by_mac(const struct client *a, const struct client *b) { return memcmp(&a->mac, &b->mac, ETH_ALEN); }

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -793,10 +793,10 @@ bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client) {
 	for (int i = VECTOR_LEN(foreign_client->addresses) - 1; i >= 0; i--) {
 		struct client_ip *foreign_ip =
 		    &VECTOR_INDEX(foreign_client->addresses, i);
-		struct client_ip *ip = get_client_ip(client, &foreign_ip->addr);
+		bool is_client_ip_known =
+		    get_client_ip(client, &foreign_ip->addr);
 
-		// Skip if we already know this IP address
-		if (ip != NULL)
+		if (!is_client_ip_known)
 			continue;
 
 		clientmgr_add_address(ctx, &foreign_ip->addr,

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -429,6 +429,8 @@ void clientmgr_delete_client(clientmgr_ctx *ctx, uint8_t mac[ETH_ALEN]) {
 	    print_mac(mac));
 	print_client(client);
 
+	intercom_remove_claim(&l3ctx.intercom_ctx, client);
+
 	client_copy_to_old(client);
 
 	remove_special_ip(ctx, client);

--- a/src/genl.c
+++ b/src/genl.c
@@ -12,8 +12,7 @@
 
 #include "genl.h"
 
-static int error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err,
-			 void *arg) {
+static int error_handler(struct sockaddr_nl *nla, struct nlmsgerr *err, void *arg) {
 	int *ret = arg;
 	*ret = err->error;
 	return NL_STOP;
@@ -37,8 +36,7 @@ static int family_handler(struct nl_msg *msg, void *arg) {
 	struct nlattr *mcgrp;
 	int rem_mcgrp;
 
-	nla_parse(tb, CTRL_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
-		  genlmsg_attrlen(gnlh, 0), NULL);
+	nla_parse(tb, CTRL_ATTR_MAX, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
 
 	if (!tb[CTRL_ATTR_MCAST_GROUPS])
 		return NL_SKIP;
@@ -46,14 +44,11 @@ static int family_handler(struct nl_msg *msg, void *arg) {
 	nla_for_each_nested(mcgrp, tb[CTRL_ATTR_MCAST_GROUPS], rem_mcgrp) {
 		struct nlattr *tb_mcgrp[CTRL_ATTR_MCAST_GRP_MAX + 1];
 
-		nla_parse(tb_mcgrp, CTRL_ATTR_MCAST_GRP_MAX, nla_data(mcgrp),
-			  nla_len(mcgrp), NULL);
+		nla_parse(tb_mcgrp, CTRL_ATTR_MCAST_GRP_MAX, nla_data(mcgrp), nla_len(mcgrp), NULL);
 
-		if (!tb_mcgrp[CTRL_ATTR_MCAST_GRP_NAME] ||
-		    !tb_mcgrp[CTRL_ATTR_MCAST_GRP_ID])
+		if (!tb_mcgrp[CTRL_ATTR_MCAST_GRP_NAME] || !tb_mcgrp[CTRL_ATTR_MCAST_GRP_ID])
 			continue;
-		if (strncmp(nla_data(tb_mcgrp[CTRL_ATTR_MCAST_GRP_NAME]),
-			    grp->group,
+		if (strncmp(nla_data(tb_mcgrp[CTRL_ATTR_MCAST_GRP_NAME]), grp->group,
 			    nla_len(tb_mcgrp[CTRL_ATTR_MCAST_GRP_NAME])))
 			continue;
 		grp->id = nla_get_u32(tb_mcgrp[CTRL_ATTR_MCAST_GRP_ID]);
@@ -63,8 +58,7 @@ static int family_handler(struct nl_msg *msg, void *arg) {
 	return NL_SKIP;
 }
 
-int nl_get_multicast_id(struct nl_sock *sock, const char *family,
-			const char *group) {
+int nl_get_multicast_id(struct nl_sock *sock, const char *family, const char *group) {
 	struct nl_msg *msg;
 	struct nl_cb *cb;
 	int ret, ctrlid;

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -463,9 +463,9 @@ struct client *find_repeatable(void *v, client_t *k, int *elementindex) {
 			*elementindex = VECTOR_GETINDEX(vec, ret);
 			log_debug(" on index %i", *elementindex);
 		}
+		log_debug("\n");
 	}
 
-	log_debug("\n");
 	return ret;
 }
 

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -460,7 +460,7 @@ struct client *find_repeatable(void *v, client_t *k, int *elementindex) {
 		log_debug("match on vector for mac %s", print_mac(k->mac));
 
 		if (elementindex != NULL) {
-			*elementindex = ((void *)ret - (void *)&VECTOR_INDEX(vec, 0)) / sizeof(struct unknown_address);
+			*elementindex = VECTOR_GETINDEX(vec, ret);
 			log_debug(" on index %i", *elementindex);
 		}
 	}

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -516,8 +516,7 @@ bool intercom_handle_info(intercom_ctx *ctx, intercom_packet_info *packet, int p
 	while (currentoffset < packet_len) {
 		packetpointer = &((uint8_t *)packet)[currentoffset];
 		type = *packetpointer;
-		if (l3ctx.debug)
-			printf("offset: %i %p %p\n", currentoffset, packet, packetpointer);
+		log_debug("offset: %i %p %p\n", currentoffset, packet, packetpointer);
 		switch (type) {
 			case INFO_PLAT:
 				currentoffset += parse_plat(packetpointer, &client);

--- a/src/intercom.h
+++ b/src/intercom.h
@@ -13,11 +13,10 @@
 #include <stdlib.h>
 
 #define L3ROAMD_PACKET_FORMAT_VERSION 0
-#define INFO_MAX \
-	15  // this amount * sizeof(in6_addr) + 6 (mac-address) + 2 (type,
-	    // lenght) must fit into uint8_t. If we have more than 15 IP
-	    // addresses for a single client, we could implement sending
-	    // multiple segments of type INFO_BASIC.
+#define INFO_MAX 15  // this amount * sizeof(in6_addr) + 6 (mac-address) + 2 (type,
+		     // length) must fit into uint8_t. If we have more than 15 IP
+		     // addresses for a single client, we could implement sending
+		     // multiple segments of type INFO_BASIC.
 #define CLAIM_RETRY_MAX 15
 #define INFO_RETRY_MAX 15
 
@@ -79,9 +78,7 @@ typedef struct __attribute__((__packed__)) {
 	// expected
 } intercom_packet_info_basic;
 
-typedef struct __attribute__((__packed__)) {
-	uint8_t address[16];
-} intercom_packet_info_entry;
+typedef struct __attribute__((__packed__)) { uint8_t address[16]; } intercom_packet_info_entry;
 
 typedef struct intercom_if {
 	char *ifname;
@@ -113,11 +110,8 @@ typedef struct {
 	int mtu;
 } intercom_ctx;
 
-// struct client;
-
 void intercom_recently_seen_add(intercom_ctx *ctx, intercom_packet_hdr *hdr);
-void intercom_send_packet(intercom_ctx *ctx, uint8_t *packet,
-			  ssize_t packet_len);
+void intercom_send_packet(intercom_ctx *ctx, uint8_t *packet, ssize_t packet_len);
 void intercom_seek(intercom_ctx *ctx, const struct in6_addr *address);
 void intercom_init_unicast(intercom_ctx *ctx);
 void intercom_init(intercom_ctx *ctx);
@@ -125,9 +119,6 @@ void intercom_handle_in(intercom_ctx *ctx, int fd);
 bool intercom_add_interface(intercom_ctx *ctx, char *ifname);
 bool intercom_del_interface(intercom_ctx *ctx, char *ifname);
 void intercom_update_interfaces(intercom_ctx *ctx);
-bool intercom_info(intercom_ctx *ctx, const struct in6_addr *recipient,
-		   struct client *client, bool relinquished);
-bool intercom_claim(intercom_ctx *ctx, const struct in6_addr *recipient,
-		    struct client *client);
-bool intercom_ack(intercom_ctx *ctx, const struct in6_addr *recipient,
-		  struct client *client);
+bool intercom_info(intercom_ctx *ctx, const struct in6_addr *recipient, struct client *client, bool relinquished);
+bool intercom_claim(intercom_ctx *ctx, const struct in6_addr *recipient, struct client *client);
+bool intercom_ack(intercom_ctx *ctx, const struct in6_addr *recipient, struct client *client);

--- a/src/intercom.h
+++ b/src/intercom.h
@@ -119,6 +119,7 @@ void intercom_handle_in(intercom_ctx *ctx, int fd);
 bool intercom_add_interface(intercom_ctx *ctx, char *ifname);
 bool intercom_del_interface(intercom_ctx *ctx, char *ifname);
 void intercom_update_interfaces(intercom_ctx *ctx);
+void intercom_remove_claim(intercom_ctx *ctx, struct client *client);
 bool intercom_info(intercom_ctx *ctx, const struct in6_addr *recipient, struct client *client, bool relinquished);
 bool intercom_claim(intercom_ctx *ctx, const struct in6_addr *recipient, struct client *client);
 bool intercom_ack(intercom_ctx *ctx, const struct in6_addr *recipient, struct client *client);

--- a/src/main.c
+++ b/src/main.c
@@ -61,19 +61,16 @@ void sig_term_handler(int signum, siginfo_t *info, void *ptr) {
 
 	for (int i = VECTOR_LEN(l3ctx.clientmgr_ctx.prefixes); i > 0; i--) {
 		del_prefix(&l3ctx.clientmgr_ctx.prefixes, _prefix);
-		routemgr_remove_route(
-		    &l3ctx.routemgr_ctx, 254,
-		    (struct in6_addr *)(_prefix.prefix.s6_addr), _prefix.plen);
+		routemgr_remove_route(&l3ctx.routemgr_ctx, 254, (struct in6_addr *)(_prefix.prefix.s6_addr),
+				      _prefix.plen);
 	}
 	clientmgr_purge_clients(&l3ctx.clientmgr_ctx);
 	_exit(EXIT_SUCCESS);
 }
 
 bool intercom_ready(const int fd) {
-	for (int j = VECTOR_LEN(l3ctx.intercom_ctx.interfaces) - 1; j >= 0;
-	     j--) {
-		if (VECTOR_INDEX(l3ctx.intercom_ctx.interfaces, j)
-			.mcast_recv_fd == fd) {
+	for (int j = VECTOR_LEN(l3ctx.intercom_ctx.interfaces) - 1; j >= 0; j--) {
+		if (VECTOR_INDEX(l3ctx.intercom_ctx.interfaces, j).mcast_recv_fd == fd) {
 			log_debug(
 			    "received intercom packet on one of the mesh "
 			    "interfaces\n");
@@ -164,11 +161,8 @@ void loop() {
 			add_fd(efd, l3ctx.wifistations_ctx.fd, EPOLLIN);
 	}
 
-	for (int i = VECTOR_LEN(l3ctx.intercom_ctx.interfaces) - 1; i >= 0;
-	     i--) {
-		add_fd(efd, VECTOR_INDEX(l3ctx.intercom_ctx.interfaces, i)
-				.mcast_recv_fd,
-		       EPOLLIN);
+	for (int i = VECTOR_LEN(l3ctx.intercom_ctx.interfaces) - 1; i >= 0; i--) {
+		add_fd(efd, VECTOR_INDEX(l3ctx.intercom_ctx.interfaces, i).mcast_recv_fd, EPOLLIN);
 	}
 
 	if (l3ctx.socket_ctx.fd >= 0)
@@ -187,96 +181,77 @@ void loop() {
 			    "routemgr: %i ipmgr: %i icmp6: %i icmp6.ns: %i "
 			    "arp: %i socket: %i, wifistations: %i, "
 			    "intercom_unicast_nodeip_fd: %i - ",
-			    events[i].data.fd, l3ctx.taskqueue_ctx.fd,
-			    l3ctx.routemgr_ctx.fd, l3ctx.ipmgr_ctx.fd,
-			    l3ctx.icmp6_ctx.fd, l3ctx.icmp6_ctx.nsfd,
-			    l3ctx.arp_ctx.fd, l3ctx.socket_ctx.fd,
-			    l3ctx.wifistations_ctx.fd,
-			    l3ctx.intercom_ctx.unicast_nodeip_fd);
+			    events[i].data.fd, l3ctx.taskqueue_ctx.fd, l3ctx.routemgr_ctx.fd, l3ctx.ipmgr_ctx.fd,
+			    l3ctx.icmp6_ctx.fd, l3ctx.icmp6_ctx.nsfd, l3ctx.arp_ctx.fd, l3ctx.socket_ctx.fd,
+			    l3ctx.wifistations_ctx.fd, l3ctx.intercom_ctx.unicast_nodeip_fd);
 
-			if ((events[i].events & EPOLLERR) ||
-			    (events[i].events & EPOLLHUP) ||
+			if ((events[i].events & EPOLLERR) || (events[i].events & EPOLLHUP) ||
 			    (!(events[i].events & EPOLLIN))) {
-				fprintf(
-				    stderr,
-				    "epoll error received on fd %i. Dumping "
-				    "fd: taskqueue.fd: %i routemgr: %i ipmgr: "
-				    "%i icmp6: %i icmp6.ns: %i arp: %i socket: "
-				    "%i, wifistations: %i ... continuing\n",
-				    events[i].data.fd, l3ctx.taskqueue_ctx.fd,
-				    l3ctx.routemgr_ctx.fd, l3ctx.ipmgr_ctx.fd,
-				    l3ctx.icmp6_ctx.fd, l3ctx.icmp6_ctx.nsfd,
-				    l3ctx.arp_ctx.fd, l3ctx.socket_ctx.fd,
-				    l3ctx.wifistations_ctx.fd);
+				fprintf(stderr,
+					"epoll error received on fd %i. Dumping "
+					"fd: taskqueue.fd: %i routemgr: %i ipmgr: "
+					"%i icmp6: %i icmp6.ns: %i arp: %i socket: "
+					"%i, wifistations: %i ... continuing\n",
+					events[i].data.fd, l3ctx.taskqueue_ctx.fd, l3ctx.routemgr_ctx.fd,
+					l3ctx.ipmgr_ctx.fd, l3ctx.icmp6_ctx.fd, l3ctx.icmp6_ctx.nsfd, l3ctx.arp_ctx.fd,
+					l3ctx.socket_ctx.fd, l3ctx.wifistations_ctx.fd);
 				if (reconnect_fd(events[i].data.fd))
 					continue;
 				perror(
 				    "epoll error without contingency plan. "
 				    "Exiting now.");
 				sig_term_handler(0, 0, 0);
-			} else if (l3ctx.wifistations_ctx.fd ==
-				   events[i].data.fd) {
+			} else if (l3ctx.wifistations_ctx.fd == events[i].data.fd) {
 				wifistations_handle_in(&l3ctx.wifistations_ctx);
-			} else if (l3ctx.taskqueue_ctx.fd ==
-				   events[i].data.fd) {
+			} else if (l3ctx.taskqueue_ctx.fd == events[i].data.fd) {
 				taskqueue_run(&l3ctx.taskqueue_ctx);
 			} else if (l3ctx.routemgr_ctx.fd == events[i].data.fd) {
 				if (events[i].events & EPOLLIN) {
 					log_debug(" INBOUND\n");
-					routemgr_handle_in(&l3ctx.routemgr_ctx,
-							   events[i].data.fd);
+					routemgr_handle_in(&l3ctx.routemgr_ctx, events[i].data.fd);
 				} else {
 					log_debug("\n");
 				}
 			} else if (l3ctx.ipmgr_ctx.fd == events[i].data.fd) {
 				if (events[i].events & EPOLLIN)
-					ipmgr_handle_in(&l3ctx.ipmgr_ctx,
-							events[i].data.fd);
-			} else if (l3ctx.icmp6_ctx.unreachfd6 ==
-				   events[i].data.fd) {
+					ipmgr_handle_in(&l3ctx.ipmgr_ctx, events[i].data.fd);
+			} else if (l3ctx.icmp6_ctx.unreachfd6 == events[i].data.fd) {
 				unsigned char trash[l3ctx.client_mtu];
-				int amount = read(
-				    l3ctx.icmp6_ctx.unreachfd6, trash,
-				    l3ctx.client_mtu);  // TODO: why do we even
-							// have to read here?
-							// This should be
-							// write-only
+				int amount = read(l3ctx.icmp6_ctx.unreachfd6, trash,
+						  l3ctx.client_mtu);  // TODO: why do we even
+								      // have to read here?
+								      // This should be
+								      // write-only
 				log_debug(
 				    "ignoring bogus data on unreachfd6, %i "
 				    "Bytes\n",
 				    amount);
-			} else if (l3ctx.icmp6_ctx.unreachfd4 ==
-				   events[i].data.fd) {
+			} else if (l3ctx.icmp6_ctx.unreachfd4 == events[i].data.fd) {
 				unsigned char trash[l3ctx.client_mtu];
-				int amount = read(
-				    l3ctx.icmp6_ctx.unreachfd4, trash,
-				    l3ctx.client_mtu);  // TODO: why do we even
-							// have to read here?
-							// This should be
-							// write-only
+				int amount = read(l3ctx.icmp6_ctx.unreachfd4, trash,
+						  l3ctx.client_mtu);  // TODO: why do we even
+								      // have to read here?
+								      // This should be
+								      // write-only
 				log_debug(
 				    "ignoring bogus data on unreachfd4, %i "
 				    "Bytes\n",
 				    amount);
 			} else if (l3ctx.icmp6_ctx.fd == events[i].data.fd) {
 				if (events[i].events & EPOLLIN)
-					icmp6_handle_in(&l3ctx.icmp6_ctx,
-							events[i].data.fd);
+					icmp6_handle_in(&l3ctx.icmp6_ctx, events[i].data.fd);
 			} else if (l3ctx.icmp6_ctx.nsfd == events[i].data.fd) {
 				if (events[i].events & EPOLLIN)
-					icmp6_handle_ns_in(&l3ctx.icmp6_ctx,
-							   events[i].data.fd);
+					icmp6_handle_ns_in(&l3ctx.icmp6_ctx, events[i].data.fd);
 			} else if (l3ctx.arp_ctx.fd == events[i].data.fd) {
 				if (events[i].events & EPOLLIN)
-					arp_handle_in(&l3ctx.arp_ctx,
-						      events[i].data.fd);
+					arp_handle_in(&l3ctx.arp_ctx, events[i].data.fd);
 			} else if (l3ctx.socket_ctx.fd == events[i].data.fd) {
 				socket_handle_in(&l3ctx.socket_ctx);
 			} else if (intercom_ready(events[i].data.fd)) {
 				log_debug("handling intercom event\n");
 				if (events[i].events & EPOLLIN)
-					intercom_handle_in(&l3ctx.intercom_ctx,
-							   events[i].data.fd);
+					intercom_handle_in(&l3ctx.intercom_ctx, events[i].data.fd);
 			} else {
 				char buffer[512];
 				int tmp = read(events[i].data.fd, buffer, 512);
@@ -435,20 +410,17 @@ int main(int argc, char *argv[]) {
 
 	intercom_init(&l3ctx.intercom_ctx);
 	int c;
-	while ((c = getopt_long(argc, argv, "dhva:b:e:p:i:m:t:c:4:n:s:d:VD:P:",
-				long_options, &option_index)) != -1)
+	while ((c = getopt_long(argc, argv, "dhva:b:e:p:i:m:t:c:4:n:s:d:VD:P:", long_options, &option_index)) != -1)
 		switch (c) {
 			case 'V':
 				printf("l3roamd %s\n", SOURCE_VERSION);
 #if defined(GIT_BRANCH) && defined(GIT_COMMIT_HASH)
-				printf("branch: %s\n commit: %s\n", GIT_BRANCH,
-				       GIT_COMMIT_HASH);
+				printf("branch: %s\n commit: %s\n", GIT_BRANCH, GIT_COMMIT_HASH);
 #endif
 				exit(EXIT_SUCCESS);
 			case 'b':
 				free(l3ctx.routemgr_ctx.client_bridge);
-				l3ctx.routemgr_ctx.client_bridge =
-				    strdupa(optarg);
+				l3ctx.routemgr_ctx.client_bridge = strdupa(optarg);
 				break;
 			case 'h':
 				usage();
@@ -459,8 +431,7 @@ int main(int argc, char *argv[]) {
 					    "-a must not be specified more "
 					    "than once");
 
-				if (inet_pton(AF_INET6, optarg,
-					      &l3ctx.intercom_ctx.ip) != 1)
+				if (inet_pton(AF_INET6, optarg, &l3ctx.intercom_ctx.ip) != 1)
 					exit_error("Can not parse IP address");
 				intercom_init_unicast(&l3ctx.intercom_ctx);
 				a_initialized = true;
@@ -476,18 +447,15 @@ int main(int argc, char *argv[]) {
 					exit_error(
 					    "Can not parse node-client-prefix "
 					    "that passed by -P");
-				l3ctx.clientmgr_ctx.node_client_prefix =
-				    _ncprefix;
+				l3ctx.clientmgr_ctx.node_client_prefix = _ncprefix;
 				break;
 			case 'p': {
 				struct prefix _prefix = {};
 				if (!parse_prefix(&_prefix, optarg)) {
-					fprintf(stderr, "prefix: %s - ",
-						optarg);
+					fprintf(stderr, "prefix: %s - ", optarg);
 					exit_error("Can not parse prefix");
 				}
-				add_prefix(&l3ctx.clientmgr_ctx.prefixes,
-					   _prefix);
+				add_prefix(&l3ctx.clientmgr_ctx.prefixes, _prefix);
 				p_initialized = true;
 			} break;
 			case 'e': {
@@ -501,30 +469,24 @@ int main(int argc, char *argv[]) {
 				l3ctx.clientmgr_ctx.platprefix_set = true;
 			} break;
 			case '4':
-				if (!parse_prefix(&l3ctx.clientmgr_ctx.v4prefix,
-						  optarg))
+				if (!parse_prefix(&l3ctx.clientmgr_ctx.v4prefix, optarg))
 					exit_error("Can not parse IPv4 prefix");
 
 				// if (l3ctx.clientmgr_ctx.v4prefix.plen != 96)
 				//	exit_error("IPv4 prefix must be /96");
 
-				l3ctx.arp_ctx.prefix =
-				    l3ctx.clientmgr_ctx.v4prefix.prefix;
+				l3ctx.arp_ctx.prefix = l3ctx.clientmgr_ctx.v4prefix.prefix;
 
 				v4_initialized = true;
 				break;
 			case 'i':
-				if (if_nametoindex(optarg) &&
-				    !l3ctx.clientif_set) {
+				if (if_nametoindex(optarg) && !l3ctx.clientif_set) {
 					free(l3ctx.routemgr_ctx.clientif);
 					free(l3ctx.icmp6_ctx.clientif);
 					free(l3ctx.arp_ctx.clientif);
-					l3ctx.routemgr_ctx.clientif =
-					    strdupa(optarg);
-					l3ctx.icmp6_ctx.clientif =
-					    strdupa(optarg);
-					l3ctx.arp_ctx.clientif =
-					    strdupa(optarg);
+					l3ctx.routemgr_ctx.clientif = strdupa(optarg);
+					l3ctx.icmp6_ctx.clientif = strdupa(optarg);
+					l3ctx.arp_ctx.clientif = strdupa(optarg);
 					l3ctx.clientif_set = true;
 				} else {
 					fprintf(stderr,
@@ -538,8 +500,7 @@ int main(int argc, char *argv[]) {
 				}
 				break;
 			case 'm':
-				intercom_add_interface(&l3ctx.intercom_ctx,
-						       strdup(optarg));
+				intercom_add_interface(&l3ctx.intercom_ctx, strdup(optarg));
 				m_initialized = true;
 				break;
 			case 't':
@@ -555,8 +516,7 @@ int main(int argc, char *argv[]) {
 				l3ctx.verbose = true;
 				break;
 			case 'n':
-				l3ctx.clientmgr_ctx.nat46ifindex =
-				    if_nametoindex(optarg);
+				l3ctx.clientmgr_ctx.nat46ifindex = if_nametoindex(optarg);
 				break;
 			case 'D':
 				free(l3ctx.l3device);
@@ -572,8 +532,7 @@ int main(int argc, char *argv[]) {
 				l3ctx.wifistations_ctx.nl80211_disabled = true;
 				break;
 			default:
-				fprintf(stderr,
-					"Invalid parameter %c ignored.\n", c);
+				fprintf(stderr, "Invalid parameter %c ignored.\n", c);
 		}
 
 	if (!v4_initialized) {
@@ -599,8 +558,7 @@ int main(int argc, char *argv[]) {
 
 	socket_init(&l3ctx.socket_ctx, socketpath);
 	if (!ipmgr_init(&l3ctx.ipmgr_ctx, l3ctx.l3device, 9000))
-		exit_error(
-		    "could not open the tun device for l3roamd. exiting now\n");
+		exit_error("could not open the tun device for l3roamd. exiting now\n");
 
 	routemgr_init(&l3ctx.routemgr_ctx);
 	if (l3ctx.clientif_set) {

--- a/src/packet.c
+++ b/src/packet.c
@@ -12,13 +12,9 @@ static struct in6_addr packet_get_ip4(const uint8_t packet[], int offset) {
 	return src6;
 }
 
-static struct in6_addr packet_get_src4(const uint8_t packet[]) {
-	return packet_get_ip4(packet, 12);
-}
+static struct in6_addr packet_get_src4(const uint8_t packet[]) { return packet_get_ip4(packet, 12); }
 
-static struct in6_addr packet_get_dst4(const uint8_t packet[]) {
-	return packet_get_ip4(packet, 16);
-}
+static struct in6_addr packet_get_dst4(const uint8_t packet[]) { return packet_get_ip4(packet, 16); }
 
 static struct in6_addr packet_get_ip6(const uint8_t packet[], int offset) {
 	struct in6_addr src;
@@ -26,13 +22,9 @@ static struct in6_addr packet_get_ip6(const uint8_t packet[], int offset) {
 	return src;
 }
 
-static struct in6_addr packet_get_src6(const uint8_t packet[]) {
-	return packet_get_ip6(packet, 8);
-}
+static struct in6_addr packet_get_src6(const uint8_t packet[]) { return packet_get_ip6(packet, 8); }
 
-static struct in6_addr packet_get_dst6(const uint8_t packet[]) {
-	return packet_get_ip6(packet, 24);
-}
+static struct in6_addr packet_get_dst6(const uint8_t packet[]) { return packet_get_ip6(packet, 24); }
 
 uint8_t packet_ipv4_get_header_length(const uint8_t packet[]) {
 	return (packet[0] & 0x0f) << 2;  // IHL * 32 / 8 = IHL * 32/4 = IHL << 2
@@ -43,17 +35,11 @@ uint16_t packet_ipv4_get_length(const uint8_t packet[]) {
 	return length;
 }
 
-static bool packet_isv4(const uint8_t packet[]) {
-	return (packet[0] & 0xf0) == 0x40;
-}
+static bool packet_isv4(const uint8_t packet[]) { return (packet[0] & 0xf0) == 0x40; }
 
-static bool packet_isv6(const uint8_t packet[]) {
-	return (packet[0] & 0xf0) == 0x60;
-}
+static bool packet_isv6(const uint8_t packet[]) { return (packet[0] & 0xf0) == 0x60; }
 
-uint8_t packet_get_family(const uint8_t packet[]) {
-	return (packet_isv6(packet) ? AF_INET6 : AF_INET);
-}
+uint8_t packet_get_family(const uint8_t packet[]) { return (packet_isv6(packet) ? AF_INET6 : AF_INET); }
 
 struct in6_addr packet_get_src(const uint8_t packet[]) {
 	if (packet_isv4(packet))

--- a/src/prefix.c
+++ b/src/prefix.c
@@ -86,8 +86,7 @@ bool add_prefix(void *prefixes, struct prefix _prefix) {
 bool del_prefix(void *prefixes, struct prefix _prefix) {
 	VECTOR(struct prefix) *_prefixes = prefixes;
 	for (int i = 0; i < VECTOR_LEN(*_prefixes); i++) {
-		if (!memcmp(&VECTOR_INDEX(*_prefixes, i), &_prefix,
-			    sizeof(_prefix))) {
+		if (!memcmp(&VECTOR_INDEX(*_prefixes, i), &_prefix, sizeof(_prefix))) {
 			VECTOR_DELETE(*_prefixes, i);
 			return true;
 		}
@@ -97,12 +96,10 @@ bool del_prefix(void *prefixes, struct prefix _prefix) {
 }
 
 bool prefix_contains(const struct prefix *prefix, const struct in6_addr *addr) {
-	log_debug("checking if prefix %s contains address %s\n",
-		  print_ip(&prefix->prefix), print_ip(addr));
+	log_debug("checking if prefix %s contains address %s\n", print_ip(&prefix->prefix), print_ip(addr));
 
 	int mask = 0xff;
-	for (int remaining_plen = prefix->plen, i = 0; remaining_plen > 0;
-	     remaining_plen -= 8) {
+	for (int remaining_plen = prefix->plen, i = 0; remaining_plen > 0; remaining_plen -= 8) {
 		if (remaining_plen < 8)
 			mask = 0xff & (0xff00 >> remaining_plen);
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -48,10 +48,8 @@ void socket_init(socket_ctx *ctx, char *path) {
 	unlink(path);
 
 	size_t status_socket_len = strlen(path);
-	size_t len =
-	    offsetof(struct sockaddr_un, sun_path) + status_socket_len + 1;
-	uint8_t buf[len]
-	    __attribute__((aligned(__alignof__(struct sockaddr_un))));
+	size_t len = offsetof(struct sockaddr_un, sun_path) + status_socket_len + 1;
+	uint8_t buf[len] __attribute__((aligned(__alignof__(struct sockaddr_un))));
 	memset(buf, 0, offsetof(struct sockaddr_un, sun_path));
 
 	struct sockaddr_un *sa = (struct sockaddr_un *)buf;
@@ -109,10 +107,8 @@ void socket_get_meshifs(struct json_object *obj) {
 	struct json_object *jmeshifs = json_object_new_array();
 
 	for (int i = 0; i < VECTOR_LEN(l3ctx.intercom_ctx.interfaces); i++) {
-		intercom_if_t *iface =
-		    &VECTOR_INDEX(l3ctx.intercom_ctx.interfaces, i);
-		json_object_array_add(jmeshifs,
-				      json_object_new_string(iface->ifname));
+		intercom_if_t *iface = &VECTOR_INDEX(l3ctx.intercom_ctx.interfaces, i);
+		json_object_array_add(jmeshifs, json_object_new_string(iface->ifname));
 	}
 	json_object_object_add(obj, "mesh_interfaces", jmeshifs);
 }
@@ -121,17 +117,13 @@ void socket_get_prefixes(struct json_object *obj) {
 	struct json_object *jprefixes = json_object_new_array();
 	char str_prefix[INET6_ADDRSTRLEN] = {};
 
-	inet_ntop(AF_INET6, &l3ctx.clientmgr_ctx.v4prefix.prefix, str_prefix,
-		  INET6_ADDRSTRLEN);
+	inet_ntop(AF_INET6, &l3ctx.clientmgr_ctx.v4prefix.prefix, str_prefix, INET6_ADDRSTRLEN);
 	json_object_array_add(jprefixes, json_object_new_string(str_prefix));
 
 	for (int i = 0; i < VECTOR_LEN(l3ctx.clientmgr_ctx.prefixes); i++) {
-		struct prefix *_prefix =
-		    &VECTOR_INDEX(l3ctx.clientmgr_ctx.prefixes, i);
-		inet_ntop(AF_INET6, &_prefix->prefix, str_prefix,
-			  INET6_ADDRSTRLEN);
-		json_object_array_add(jprefixes,
-				      json_object_new_string(str_prefix));
+		struct prefix *_prefix = &VECTOR_INDEX(l3ctx.clientmgr_ctx.prefixes, i);
+		inet_ntop(AF_INET6, &_prefix->prefix, str_prefix, INET6_ADDRSTRLEN);
+		json_object_array_add(jprefixes, json_object_new_string(str_prefix));
 	}
 	json_object_object_add(obj, "prefixes", jprefixes);
 }
@@ -140,33 +132,25 @@ void get_clients(struct json_object *obj) {
 	int i = 0, j = 0;
 	struct json_object *jclients = json_object_new_object();
 
-	json_object_object_add(
-	    obj, "clients",
-	    json_object_new_int(VECTOR_LEN(l3ctx.clientmgr_ctx.clients)));
+	json_object_object_add(obj, "clients", json_object_new_int(VECTOR_LEN(l3ctx.clientmgr_ctx.clients)));
 
 	for (i = 0; i < VECTOR_LEN(l3ctx.clientmgr_ctx.clients); i++) {
-		struct client *_client =
-		    &VECTOR_INDEX(l3ctx.clientmgr_ctx.clients, i);
+		struct client *_client = &VECTOR_INDEX(l3ctx.clientmgr_ctx.clients, i);
 		struct json_object *jclient = json_object_new_object();
 
 		char ifname[IFNAMSIZ] = "";
 
 		if_indextoname(_client->ifindex, ifname);
-		json_object_object_add(jclient, "interface",
-				       json_object_new_string(ifname));
+		json_object_object_add(jclient, "interface", json_object_new_string(ifname));
 
 		struct json_object *addresses = json_object_new_object();
 		for (j = 0; j < VECTOR_LEN(_client->addresses); j++) {
 			struct json_object *address = json_object_new_object();
-			struct client_ip *_client_ip =
-			    &VECTOR_INDEX(_client->addresses, j);
+			struct client_ip *_client_ip = &VECTOR_INDEX(_client->addresses, j);
 			char ip_str[INET6_ADDRSTRLEN] = "";
-			inet_ntop(AF_INET6, &_client_ip->addr, ip_str,
-				  INET6_ADDRSTRLEN);
+			inet_ntop(AF_INET6, &_client_ip->addr, ip_str, INET6_ADDRSTRLEN);
 
-			json_object_object_add(
-			    address, "state",
-			    json_object_new_int(_client_ip->state));
+			json_object_object_add(address, "state", json_object_new_int(_client_ip->state));
 			json_object_object_add(addresses, ip_str, address);
 		}
 
@@ -176,8 +160,7 @@ void get_clients(struct json_object *obj) {
 			json_object_put(addresses);
 		}
 
-		json_object_object_add(jclients, print_mac(_client->mac),
-				       jclient);
+		json_object_object_add(jclients, print_mac(_client->mac), jclient);
 	}
 
 	if (i) {
@@ -208,8 +191,7 @@ void socket_handle_in(socket_ctx *ctx) {
 
 	enum socket_command cmd;
 	if (!parse_command(line, &cmd)) {
-		fprintf(stderr, "Could not parse command on socket (%s)\n",
-			line);
+		fprintf(stderr, "Could not parse command on socket (%s)\n", line);
 		goto end;
 	}
 
@@ -225,15 +207,11 @@ void socket_handle_in(socket_ctx *ctx) {
 		case PROBE:
 			str_address = strtok(&line[ETH_ALEN], " ");
 			str_mac = strtok(NULL, " ");
-			sscanf(str_mac,
-			       "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
-			       &mac[0], &mac[1], &mac[2], &mac[3], &mac[4],
-			       &mac[5]);
+			sscanf(str_mac, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &mac[0], &mac[1], &mac[2], &mac[3],
+			       &mac[4], &mac[5]);
 			if (inet_pton(AF_INET6, str_address, &address) == 1) {
-				routemgr_probe_neighbor(
-				    &l3ctx.routemgr_ctx,
-				    l3ctx.routemgr_ctx.clientif_index, &address,
-				    mac);
+				routemgr_probe_neighbor(&l3ctx.routemgr_ctx, l3ctx.routemgr_ctx.clientif_index,
+							&address, mac);
 			}
 			break;
 		case GET_CLIENTS:
@@ -243,34 +221,26 @@ void socket_handle_in(socket_ctx *ctx) {
 		case ADD_PREFIX:
 			if (parse_prefix(&_prefix, &line[11])) {
 				add_prefix(&CTX(clientmgr)->prefixes, _prefix);
-				routemgr_insert_route(
-				    CTX(routemgr), 254,
-				    if_nametoindex(CTX(ipmgr)->ifname),
-				    (struct in6_addr *)(_prefix.prefix.s6_addr),
-				    _prefix.plen);
+				routemgr_insert_route(CTX(routemgr), 254, if_nametoindex(CTX(ipmgr)->ifname),
+						      (struct in6_addr *)(_prefix.prefix.s6_addr), _prefix.plen);
 				dprintf(fd, "Added prefix: %s", &line[11]);
 			}
 			break;
 		case ADD_ADDRESS:
 			str_address = strtok(&line[12], " ");
 			str_mac = strtok(NULL, " ");
-			sscanf(str_mac,
-			       "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
-			       &mac[0], &mac[1], &mac[2], &mac[3], &mac[4],
-			       &mac[5]);
+			sscanf(str_mac, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &mac[0], &mac[1], &mac[2], &mac[3],
+			       &mac[4], &mac[5]);
 			if (inet_pton(AF_INET6, str_address, &address) == 1) {
-				clientmgr_add_address(
-				    &l3ctx.clientmgr_ctx, &address, mac,
-				    l3ctx.routemgr_ctx.clientif_index);
+				clientmgr_add_address(&l3ctx.clientmgr_ctx, &address, mac,
+						      l3ctx.routemgr_ctx.clientif_index);
 				dprintf(fd, "OK");
 			} else {
 				struct in_addr ip4;
-				if (inet_pton(AF_INET, str_address, &ip4) ==
-				    1) {
+				if (inet_pton(AF_INET, str_address, &ip4) == 1) {
 					mapv4_v6(&ip4, &address);
-					clientmgr_add_address(
-					    &l3ctx.clientmgr_ctx, &address, mac,
-					    l3ctx.routemgr_ctx.clientif_index);
+					clientmgr_add_address(&l3ctx.clientmgr_ctx, &address, mac,
+							      l3ctx.routemgr_ctx.clientif_index);
 					dprintf(fd, "OK");
 				} else
 					dprintf(fd, "NOT OK");
@@ -278,8 +248,7 @@ void socket_handle_in(socket_ctx *ctx) {
 			break;
 		case ADD_MESHIF:
 			str_meshif = strndup(&line[11], IFNAMSIZ);
-			if (!intercom_add_interface(&l3ctx.intercom_ctx,
-						    str_meshif)) {
+			if (!intercom_add_interface(&l3ctx.intercom_ctx, str_meshif)) {
 				free(str_meshif);
 				break;
 			}
@@ -290,21 +259,17 @@ void socket_handle_in(socket_ctx *ctx) {
 			break;
 		case DEL_MESHIF:
 			str_meshif = strndup(&line[11], IFNAMSIZ);
-			if (!intercom_del_interface(&l3ctx.intercom_ctx,
-						    str_meshif))
+			if (!intercom_del_interface(&l3ctx.intercom_ctx, str_meshif))
 				free(str_meshif);
 			break;
 		case DEL_ADDRESS:
 			str_address = strtok(&line[12], " ");
 			str_mac = strtok(NULL, " ");
-			sscanf(str_mac,
-			       "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
-			       &mac[0], &mac[1], &mac[2], &mac[3], &mac[4],
-			       &mac[5]);
+			sscanf(str_mac, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", &mac[0], &mac[1], &mac[2], &mac[3],
+			       &mac[4], &mac[5]);
 			struct client *client = get_client(mac);
 			if (client) {
-				if (inet_pton(AF_INET6, str_address,
-					      &address) == 1) {
+				if (inet_pton(AF_INET6, str_address, &address) == 1) {
 					rtmgr_client_remove_address(&address);
 					dprintf(fd, "OK");
 				} else {
@@ -315,10 +280,8 @@ void socket_handle_in(socket_ctx *ctx) {
 		case DEL_PREFIX:
 			if (parse_prefix(&_prefix, &line[11])) {
 				del_prefix(&CTX(clientmgr)->prefixes, _prefix);
-				routemgr_remove_route(
-				    CTX(routemgr), 254,
-				    (struct in6_addr *)(_prefix.prefix.s6_addr),
-				    _prefix.plen);
+				routemgr_remove_route(CTX(routemgr), 254, (struct in6_addr *)(_prefix.prefix.s6_addr),
+						      _prefix.plen);
 				dprintf(fd, "Deleted prefix: %s", &line[11]);
 			}
 			break;

--- a/src/taskqueue.c
+++ b/src/taskqueue.c
@@ -47,16 +47,14 @@ struct timespec settime(unsigned int timeout, unsigned int millisecs) {
 	struct timespec due;
 	clock_gettime(CLOCK_MONOTONIC, &due);
 
-	struct timespec t = {.tv_sec = timeout,
-			     .tv_nsec = millisecs * 1000000l};
+	struct timespec t = {.tv_sec = timeout, .tv_nsec = millisecs * 1000000l};
 
 	return timeAdd(&due, &t);
 }
 
 /** Enqueues a new task. A task with a timeout of zero is scheduled immediately.
  */
-taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout,
-		       unsigned int millisecs, void (*function)(void *),
+taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout, unsigned int millisecs, void (*function)(void *),
 		       void (*cleanup)(void *), void *data) {
 	taskqueue_t *task = l3roamd_alloc(sizeof(taskqueue_t));
 	task->children = task->next = NULL;
@@ -75,8 +73,7 @@ taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout,
 
 /** Changes the timeout of a task.
   */
-bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task,
-		     unsigned int timeout, unsigned int millisecs) {
+bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task, unsigned int timeout, unsigned int millisecs) {
 	if (task == NULL || !taskqueue_linked(task))
 		return false;
 
@@ -197,15 +194,13 @@ static taskqueue_t *taskqueue_merge_pairs(taskqueue_t *queue0) {
 
 	queue0->next = queue1->next = NULL;
 
-	return taskqueue_merge(taskqueue_merge(queue0, queue1),
-			       taskqueue_merge_pairs(queue2));
+	return taskqueue_merge(taskqueue_merge(queue0, queue1), taskqueue_merge_pairs(queue2));
 }
 
 /** Inserts a new element into a priority queue */
 void taskqueue_insert(taskqueue_t **queue, taskqueue_t *elem) {
 	if (elem->pprev || elem->next || elem->children)
-		exit_bug(
-		    "taskqueue_insert: tried to insert linked queue element");
+		exit_bug("taskqueue_insert: tried to insert linked queue element");
 
 	*queue = taskqueue_merge(elem, *queue);
 	(*queue)->pprev = queue;

--- a/src/test.c
+++ b/src/test.c
@@ -111,9 +111,8 @@ int test_mac() {
 	uint8_t mac2[ETH_ALEN] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05};
 	uint8_t mac3[ETH_ALEN] = {0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5};
 	char str[120];
-	snprintf(str, 120,
-		 "testing mac address to string conversion for: %s, %s, %s",
-		 print_mac(mac1), print_mac(mac2), print_mac(mac3));
+	snprintf(str, 120, "testing mac address to string conversion for: %s, %s, %s", print_mac(mac1), print_mac(mac2),
+		 print_mac(mac3));
 	printf("%s\n", str);
 	_assert(strncmp(str,
 			"testing mac address to string conversion for: "

--- a/src/util.c
+++ b/src/util.c
@@ -14,30 +14,26 @@ static int str_bufferoffset = 0;
 
 const char *print_ip4(const struct in_addr *addr) {
 	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
-	return inet_ntop(AF_INET, &(addr->s_addr), strbuffer[str_bufferoffset],
-			 INET6_ADDRSTRLEN);
+	return inet_ntop(AF_INET, &(addr->s_addr), strbuffer[str_bufferoffset], INET6_ADDRSTRLEN);
 }
 
 /* print a human-readable representation of an in6_addr struct to stdout
 ** */
 const char *print_ip(const struct in6_addr *addr) {
 	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
-	return inet_ntop(AF_INET6, &(addr->s6_addr),
-			 strbuffer[str_bufferoffset], INET6_ADDRSTRLEN);
+	return inet_ntop(AF_INET6, &(addr->s6_addr), strbuffer[str_bufferoffset], INET6_ADDRSTRLEN);
 }
 
 const char *print_mac(const uint8_t *mac) {
 	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
-	snprintf(strbuffer[str_bufferoffset], 18,
-		 "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", mac[0], mac[1],
-		 mac[2], mac[3], mac[4], mac[5]);
+	snprintf(strbuffer[str_bufferoffset], 18, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", mac[0], mac[1], mac[2],
+		 mac[3], mac[4], mac[5]);
 	return strbuffer[str_bufferoffset];
 }
 
 struct in_addr inline extractv4_v6(const struct in6_addr *src) {
-	struct in_addr tmp = {
-	    .s_addr = src->s6_addr[12] << 24 | src->s6_addr[13] << 16 |
-		      src->s6_addr[14] << 8 | src->s6_addr[15]};
+	struct in_addr tmp = {.s_addr = src->s6_addr[12] << 24 | src->s6_addr[13] << 16 | src->s6_addr[14] << 8 |
+					src->s6_addr[15]};
 	struct in_addr ip4;
 	ip4.s_addr = ntohl(tmp.s_addr);
 	return ip4;

--- a/src/vector.c
+++ b/src/vector.c
@@ -45,8 +45,7 @@
 
    Internal function, use VECTOR_RESIZE() instead.
 */
-void _l3roamd_vector_resize(l3roamd_vector_desc_t *desc, void **data, size_t n,
-			    size_t elemsize) {
+void _l3roamd_vector_resize(l3roamd_vector_desc_t *desc, void **data, size_t n, size_t elemsize) {
 	desc->length = n;
 
 	size_t alloc = desc->allocated;
@@ -69,8 +68,7 @@ void _l3roamd_vector_resize(l3roamd_vector_desc_t *desc, void **data, size_t n,
 
    Internal function, use VECTOR_INSERT() and VECTOR_ADD() instead.
 */
-void *_l3roamd_vector_insert(l3roamd_vector_desc_t *desc, void **data,
-			     void *element, size_t pos, size_t elemsize) {
+void *_l3roamd_vector_insert(l3roamd_vector_desc_t *desc, void **data, void *element, size_t pos, size_t elemsize) {
 	_l3roamd_vector_resize(desc, data, desc->length + 1, elemsize);
 
 	void *p = *data + pos * elemsize;
@@ -85,8 +83,7 @@ void *_l3roamd_vector_insert(l3roamd_vector_desc_t *desc, void **data,
 
    Internal function, use VECTOR_DELETE() instead.
 */
-void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
-			    size_t pos, size_t elemsize) {
+void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data, size_t pos, size_t elemsize) {
 	void *p = *data + pos * elemsize;
 	memmove(p, p + elemsize, (desc->length - pos - 1) * elemsize);
 

--- a/src/vector.h
+++ b/src/vector.h
@@ -88,6 +88,13 @@ void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data, size_t pos
 #define VECTOR_INDEX(v, i) ((v).data[i])
 
 /**
+    Given an element, return the index in the vector
+
+    \hideinitializer
+*/
+#define VECTOR_GETINDEX(v, elem) ({ (elem - v.data) / sizeof(*elem); })
+
+/**
    Returns a pointer to the vector elements of \e v
 
    \hideinitializer

--- a/src/vector.h
+++ b/src/vector.h
@@ -51,23 +51,19 @@ typedef struct l3roamd_vector_desc {
 		type *data;                 \
 	}
 
-void _l3roamd_vector_resize(l3roamd_vector_desc_t *desc, void **data, size_t n,
-			    size_t elemsize);
-void *_l3roamd_vector_insert(l3roamd_vector_desc_t *desc, void **data,
-			     void *element, size_t pos, size_t elemsize);
-void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
-			    size_t pos, size_t elemsize);
+void _l3roamd_vector_resize(l3roamd_vector_desc_t *desc, void **data, size_t n, size_t elemsize);
+void *_l3roamd_vector_insert(l3roamd_vector_desc_t *desc, void **data, void *element, size_t pos, size_t elemsize);
+void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data, size_t pos, size_t elemsize);
 
 /**
    Resizes the vector \e a to \e n elements
 
    \hideinitializer
 */
-#define VECTOR_RESIZE(v, n)                                                \
-	({                                                                 \
-		__typeof__(v) *_v = &(v);                                  \
-		_l3roamd_vector_resize(&_v->desc, (void **)&_v->data, (n), \
-				       sizeof(*_v->data));                 \
+#define VECTOR_RESIZE(v, n)                                                                    \
+	({                                                                                     \
+		__typeof__(v) *_v = &(v);                                                      \
+		_l3roamd_vector_resize(&_v->desc, (void **)&_v->data, (n), sizeof(*_v->data)); \
 	})
 
 /**
@@ -103,12 +99,11 @@ void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
 
    \hideinitializer
 */
-#define VECTOR_INSERT(v, elem, pos)                                          \
-	({                                                                   \
-		__typeof__(v) *_v = &(v);                                    \
-		__typeof__(*_v->data) _e = (elem);                           \
-		return _l3roamd_vector_insert(&_v->desc, (void **)&_v->data, \
-					      &_e, (pos), sizeof(_e));       \
+#define VECTOR_INSERT(v, elem, pos)                                                                   \
+	({                                                                                            \
+		__typeof__(v) *_v = &(v);                                                             \
+		__typeof__(*_v->data) _e = (elem);                                                    \
+		return _l3roamd_vector_insert(&_v->desc, (void **)&_v->data, &_e, (pos), sizeof(_e)); \
 	})
 
 /**
@@ -116,12 +111,11 @@ void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
 
    \hideinitializer
 */
-#define VECTOR_ADD(v, elem)                                                \
-	({                                                                 \
-		__typeof__(v) *_v = &(v);                                  \
-		__typeof__(*_v->data) _e = (elem);                         \
-		_l3roamd_vector_insert(&_v->desc, (void **)&_v->data, &_e, \
-				       _v->desc.length, sizeof(_e));       \
+#define VECTOR_ADD(v, elem)                                                                              \
+	({                                                                                               \
+		__typeof__(v) *_v = &(v);                                                                \
+		__typeof__(*_v->data) _e = (elem);                                                       \
+		_l3roamd_vector_insert(&_v->desc, (void **)&_v->data, &_e, _v->desc.length, sizeof(_e)); \
 	})
 
 /**
@@ -129,11 +123,10 @@ void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
 
    \hideinitializer
 */
-#define VECTOR_DELETE(v, pos)                                                \
-	({                                                                   \
-		__typeof__(v) *_v = &(v);                                    \
-		_l3roamd_vector_delete(&_v->desc, (void **)&_v->data, (pos), \
-				       sizeof(*_v->data));                   \
+#define VECTOR_DELETE(v, pos)                                                                    \
+	({                                                                                       \
+		__typeof__(v) *_v = &(v);                                                        \
+		_l3roamd_vector_delete(&_v->desc, (void **)&_v->data, (pos), sizeof(*_v->data)); \
 	})
 
 /**
@@ -152,14 +145,13 @@ void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
 
    \hideinitializer
 */
-#define VECTOR_BSEARCH(key, v, cmp)                                      \
-	({                                                               \
-		__typeof__(v) *_v = &(v);                                \
-		const __typeof__(*_v->data) *_key = (key);               \
-		int (*_cmp)(__typeof__(_key), __typeof__(_key)) = (cmp); \
-		(__typeof__(_v->data)) bsearch(                          \
-		    _key, _v->data, _v->desc.length, sizeof(*_v->data),  \
-		    (int (*)(const void *, const void *))_cmp);          \
+#define VECTOR_BSEARCH(key, v, cmp)                                                                \
+	({                                                                                         \
+		__typeof__(v) *_v = &(v);                                                          \
+		const __typeof__(*_v->data) *_key = (key);                                         \
+		int (*_cmp)(__typeof__(_key), __typeof__(_key)) = (cmp);                           \
+		(__typeof__(_v->data)) bsearch(_key, _v->data, _v->desc.length, sizeof(*_v->data), \
+					       (int (*)(const void *, const void *))_cmp);         \
 	})
 
 /**
@@ -168,12 +160,11 @@ void _l3roamd_vector_delete(l3roamd_vector_desc_t *desc, void **data,
 
    \hideinitializer
 */
-#define VECTOR_LSEARCH(key, v, cmp)                                            \
-	({                                                                     \
-		__typeof__(v) *_v = &(v);                                      \
-		const __typeof__(*_v->data) *_key = (key);                     \
-		int (*_cmp)(__typeof__(_key), __typeof__(_key)) = (cmp);       \
-		(__typeof__(_v->data))                                         \
-		    lfind(_key, _v->data, &_v->desc.length, sizeof(*_v->data), \
-			  (int (*)(const void *, const void *))_cmp);          \
+#define VECTOR_LSEARCH(key, v, cmp)                                                               \
+	({                                                                                        \
+		__typeof__(v) *_v = &(v);                                                         \
+		const __typeof__(*_v->data) *_key = (key);                                        \
+		int (*_cmp)(__typeof__(_key), __typeof__(_key)) = (cmp);                          \
+		(__typeof__(_v->data)) lfind(_key, _v->data, &_v->desc.length, sizeof(*_v->data), \
+					     (int (*)(const void *, const void *))_cmp);          \
 	})

--- a/src/wifistations.c
+++ b/src/wifistations.c
@@ -25,9 +25,7 @@
 
 static int no_seq_check(struct nl_msg *msg, void *arg) { return NL_OK; }
 
-void wifistations_handle_in(wifistations_ctx *ctx) {
-	nl_recvmsgs(ctx->nl_sock, ctx->cb);
-}
+void wifistations_handle_in(wifistations_ctx *ctx) { nl_recvmsgs(ctx->nl_sock, ctx->cb); }
 
 int wifistations_handle_event(struct nl_msg *msg, void *arg) {
 	if (l3ctx.debug)
@@ -45,8 +43,7 @@ int wifistations_handle_event(struct nl_msg *msg, void *arg) {
 	if (gnlh == NULL)
 		return 0;
 
-	nla_parse(tb, 8, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0),
-		  NULL);
+	nla_parse(tb, 8, genlmsg_attrdata(gnlh, 0), genlmsg_attrlen(gnlh, 0), NULL);
 
 	if (!tb[NL80211_ATTR_MAC])
 		return 0;
@@ -57,21 +54,17 @@ int wifistations_handle_event(struct nl_msg *msg, void *arg) {
 
 	switch (gnlh->cmd) {
 		case NL80211_CMD_NEW_STATION:
-			log_verbose(
-			    "new wifi station [%s] found on interface %s\n",
-			    print_mac(nla_data(tb[NL80211_ATTR_MAC])), ifname);
+			log_verbose("new wifi station [%s] found on interface %s\n",
+				    print_mac(nla_data(tb[NL80211_ATTR_MAC])), ifname);
 			ifindex = ctx->l3ctx->icmp6_ctx.ifindex;
-			clientmgr_notify_mac(CTX(clientmgr),
-					     nla_data(tb[NL80211_ATTR_MAC]),
-					     ifindex);
+			clientmgr_notify_mac(CTX(clientmgr), nla_data(tb[NL80211_ATTR_MAC]), ifindex);
 			break;
 		case NL80211_CMD_DEL_STATION:
 			log_verbose(
 			    "NL80211_CMD_DEL_STATION for [%s] RECEIVED on "
 			    "interface %s.\n",
 			    print_mac(nla_data(tb[NL80211_ATTR_MAC])), ifname);
-			clientmgr_delete_client(CTX(clientmgr),
-						nla_data(tb[NL80211_ATTR_MAC]));
+			clientmgr_delete_client(CTX(clientmgr), nla_data(tb[NL80211_ATTR_MAC]));
 			break;
 	}
 
@@ -106,8 +99,7 @@ void wifistations_init(wifistations_ctx *ctx) {
 	}
 
 	/* MLME multicast group */
-	int mcid = nl_get_multicast_id(ctx->nl_sock, NL80211_GENL_NAME,
-				       NL80211_MULTICAST_GROUP_MLME);
+	int mcid = nl_get_multicast_id(ctx->nl_sock, NL80211_GENL_NAME, NL80211_MULTICAST_GROUP_MLME);
 	if (mcid >= 0) {
 		int ret = nl_socket_add_membership(ctx->nl_sock, mcid);
 		if (ret)
@@ -122,8 +114,7 @@ void wifistations_init(wifistations_ctx *ctx) {
 		exit_error("failed to allocate netlink callbacks\n");
 
 	nl_cb_set(ctx->cb, NL_CB_SEQ_CHECK, NL_CB_CUSTOM, no_seq_check, NULL);
-	nl_cb_set(ctx->cb, NL_CB_VALID, NL_CB_CUSTOM, wifistations_handle_event,
-		  ctx);
+	nl_cb_set(ctx->cb, NL_CB_VALID, NL_CB_CUSTOM, wifistations_handle_event, ctx);
 
 	ctx->fd = nl_socket_get_fd(ctx->nl_sock);
 


### PR DESCRIPTION
This is a series of minor fixes and patches and a fix for one bigger issue:
* When connecting to a network and roaming away during the first 4.5 seconds, the client is assigned to multiple nodes at once, breaking routing to this client. 
* debug output prettificatin
* some minor refactorings
* whitespace