### PR TITLE
Remove wired-clients by interpreting RTM_DELNEIGH

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,19 +4,25 @@ list(APPEND CMAKE_REQUIRED_DEFINITIONS '-D_GNU_SOURCE')
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${L3ROAMD_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
-add_executable(l3roamd main.c socket.c config.c intercom.c arp.c ipmgr.c
-	icmp6.c syscallwrappers.c routemgr.c prefix.c vector.c wifistations.c
-	genl.c clientmgr.c taskqueue.c timespec.c util.c packet.c)
+list(APPEND COMMON_DEPS socket.c config.c intercom.c arp.c ipmgr.c icmp6.c syscallwrappers.c routemgr.c prefix.c vector.c wifistations.c genl.c clientmgr.c taskqueue.c timespec.c util.c packet.c)
+list(APPEND DAEMON_DEPS main.c)
+list(APPEND TEST_DEPS test.c)
 
-add_executable(l3roamd-test test.c socket.c config.c intercom.c arp.c ipmgr.c
-	icmp6.c syscallwrappers.c routemgr.c prefix.c vector.c wifistations.c
-	genl.c clientmgr.c taskqueue.c timespec.c util.c packet.c)
+add_library(common_libs OBJECT ${COMMON_DEPS})
+add_library(test_deps OBJECT ${TEST_DEPS})
+add_library(daemon_deps OBJECT ${DAEMON_DEPS})
+
+
+add_executable(l3roamd $<TARGET_OBJECTS:daemon_deps> $<TARGET_OBJECTS:common_libs>)
+add_executable(l3roamd-test $<TARGET_OBJECTS:test_deps> $<TARGET_OBJECTS:common_libs>)
+
 
 target_link_libraries(l3roamd ${LIBNL_LIBRARIES} ${LIBNL_GENL_LIBRARIES} ${JSON_C_LIBRARIES})
 target_link_libraries(l3roamd-test ${LIBNL_LIBRARIES} ${LIBNL_GENL_LIBRARIES} ${JSON_C_LIBRARIES})
 
 #set_target_properties(l3roamd PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wall -fsanitize=address" LINK_FLAGS " -fno-omit-frame-pointer -fsanitize=address -static-libasan")
 set_target_properties(l3roamd PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wall" LINK_FLAGS "")
+set_target_properties(l3roamd-test PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wall" LINK_FLAGS "")
 
 install(TARGETS l3roamd RUNTIME DESTINATION bin)
 

--- a/src/arp.c
+++ b/src/arp.c
@@ -48,8 +48,7 @@ void arp_handle_in(arp_ctx *ctx, int fd) {
 
 	char str[INET6_ADDRSTRLEN];
 	inet_ntop(AF_INET6, &address, str, INET6_ADDRSTRLEN);
-	log_verbose("ARP Response from %s (MAC %02x:%02x:%02x:%02x:%02x:%02x)\n", str, mac[0], mac[1], mac[2], mac[3],
-		    mac[4], mac[5]);
+	log_verbose("ARP Response from %s (MAC %s)\n", str, print_mac(mac));
 
 	clientmgr_add_address(CTX(clientmgr), &address, packet.sha, ctx->ifindex);
 }

--- a/src/arp.c
+++ b/src/arp.c
@@ -50,7 +50,7 @@ void arp_handle_in(arp_ctx *ctx, int fd) {
 	inet_ntop(AF_INET6, &address, str, INET6_ADDRSTRLEN);
 	log_verbose("ARP Response from %s (MAC %s)\n", str, print_mac(mac));
 
-	clientmgr_add_address(CTX(clientmgr), &address, packet.sha, ctx->ifindex);
+	clientmgr_add_address(&l3ctx.clientmgr_ctx, &address, packet.sha, ctx->ifindex);
 }
 
 void arp_send_request(arp_ctx *ctx, const struct in6_addr *addr) {

--- a/src/arp.h
+++ b/src/arp.h
@@ -23,7 +23,6 @@ struct __attribute__((packed)) arp_packet {
 
 typedef struct {
 	struct in6_addr prefix;
-	struct l3ctx *l3ctx;
 	char *clientif;
 	unsigned int ifindex;
 	int fd;

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -584,8 +584,8 @@ void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address, c
 
 	struct client *client = get_or_create_client(mac, ifindex);
 	struct client_ip *ip = get_client_ip(client, address);
-	client->ifindex = ifindex;  // client might have roamed to different
-	// interface on the same node
+
+	client->ifindex = ifindex;  // client might have roamed to different interface on the same node
 
 	bool ip_is_new = ip == NULL;
 
@@ -595,12 +595,12 @@ void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address, c
 		ip = VECTOR_ADD(client->addresses, _ip);
 		print_client(client);
 	}
+
 	client_ip_set_state(ctx, client, ip, IP_ACTIVE);
 
 	if (!client->claimed) {
 		struct in6_addr address = mac2ipv6(client->mac, &ctx->node_client_prefix);
-		intercom_claim(CTX(intercom), &address, client);  // this will set the special_ip after
-								  // the claiming cycle
+		intercom_claim(CTX(intercom), &address, client);  // this will set the special_ip after claiming
 	}
 }
 

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -98,10 +98,7 @@ void print_client(struct client *client) {
 					    addr->tentative_retries_left);
 				break;
 			default:
-				exit_bug(
-				    "Invalid IP state %i- exiting due to "
-				    "memory corruption",
-				    addr->state);
+				exit_bug("Invalid IP state %i- exiting due to memory corruption", addr->state);
 		}
 	}
 }
@@ -121,7 +118,6 @@ bool client_is_active(const struct client *client) {
 		struct client_ip *ip = &VECTOR_INDEX(client->addresses, i);
 
 		if (ip_is_active(ip)) {
-			log_debug("client [%s] is active on ip %s\n", print_mac(client->mac), print_ip(&ip->addr));
 			return true;
 		}
 	}
@@ -531,17 +527,14 @@ bool clientmgr_valid_address(clientmgr_ctx *ctx, const struct in6_addr *address)
 /** Remove an address from a client identified by its MAC.
 **/
 void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client, struct in6_addr *address) {
-	log_debug("clientmgr_remove_address: %s is running for client %s", print_ip(address), print_mac(client->mac));
+	log_debug("clientmgr_remove_address: %s is running for client %s\n", print_ip(address), print_mac(client->mac));
 
 	if (client) {
 		delete_client_ip(client, address, true);
 	}
 
 	if (!client_is_active(client)) {
-		log_verbose(
-		    "no active IP-addresses left in client. Deleting client. "
-		    "%s\n",
-		    print_mac(client->mac));
+		log_verbose("no active IP-addresses left in client. Deleting client. %s\n", print_mac(client->mac));
 		clientmgr_delete_client(&l3ctx.clientmgr_ctx, client->mac);
 	}
 }
@@ -741,6 +734,7 @@ bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client) {
 
 void clientmgr_init() {
 	VECTOR_INIT((&l3ctx.clientmgr_ctx)->clients);
+	VECTOR_INIT((&l3ctx.clientmgr_ctx)->oldclients);
 	post_task(&l3ctx.taskqueue_ctx, OLDCLIENTS_KEEP_SECONDS, 0, purge_oldclients_task, NULL, NULL);
 }
 

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -233,12 +233,8 @@ void delete_client_ip(struct client *client, const struct in6_addr *address, boo
 		}
 	}
 
-	char str[INET6_ADDRSTRLEN + 1];
-	inet_ntop(AF_INET6, address, str, INET6_ADDRSTRLEN);
-	printf(
-	    "\x1b[31mDeleted IP %s from client %zi addresses are still "
-	    "assigned\x1b[0m ",
-	    str, VECTOR_LEN(client->addresses));
+	log_verbose("\x1b[31mDeleted IP %s from client %zi addresses are still assigned\x1b[0m ", print_ip(address),
+		    VECTOR_LEN(client->addresses));
 	print_client(client);
 }
 
@@ -297,8 +293,6 @@ struct client *get_client_old(const uint8_t mac[ETH_ALEN]) {
  * having this IP-address and false otherwise
  */
 bool clientmgr_is_known_address(clientmgr_ctx *ctx, const struct in6_addr *address, struct client **client) {
-	// TODO: we probably should make this more efficient for large lists of
-	// clients and IP addresses at one point.
 	for (int i = VECTOR_LEN(ctx->clients) - 1; i >= 0; i--) {
 		struct client *c = &VECTOR_INDEX(ctx->clients, i);
 

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -204,7 +204,7 @@ void close_client_fd(int *fd) {
 */
 void remove_special_ip(clientmgr_ctx *ctx, struct client *client) {
 	struct in6_addr address = mac2ipv6(client->mac, &ctx->node_client_prefix);
-	printf("Removing special address: %s\n", print_ip(&address));
+	log_verbose("Removing special address: %s\n", print_ip(&address));
 	close_client_fd(&client->fd);
 	routemgr_remove_route(&l3ctx.routemgr_ctx, ctx->export_table, &address, 128);
 	rtnl_remove_address(&l3ctx.routemgr_ctx, &address);

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -561,6 +561,13 @@ void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client, struct 
 	}
 }
 
+void cancel_client_neigh_removal(struct client_ip *ip) {
+	if (ip->removal_task) {
+		drop_task(ip->removal_task);
+		ip->removal_task = NULL;
+	}
+}
+
 /** Add a new address to a client identified by its MAC.
 */
 void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address, const uint8_t *mac,
@@ -594,6 +601,8 @@ void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address, c
 		memcpy(&_ip.addr, address, sizeof(struct in6_addr));
 		ip = VECTOR_ADD(client->addresses, _ip);
 		print_client(client);
+	} else {
+		cancel_client_neigh_removal(ip);
 	}
 
 	client_ip_set_state(ctx, client, ip, IP_ACTIVE);

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -747,9 +747,9 @@ bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client) {
 
 	add_special_ip(ctx, client);
 
-	printf("Client information merged into local client ");
+	log_verbose("Client information merged into local client ");
 	print_client(client);
-	printf("\n");
+	log_verbose("\n");
 	return true;
 }
 

--- a/src/clientmgr.c
+++ b/src/clientmgr.c
@@ -154,10 +154,8 @@ int bind_to_address(struct in6_addr *address) {
 	}
 
 	if (bind(fd, (struct sockaddr *)&server_addr, sizeof(server_addr)) < 0) {
-		fprintf(stderr,
-			"Could not bind to socket %i on special ip for "
-			"address: %s. exiting.\n",
-			fd, print_ip(address));
+		fprintf(stderr, "Could not bind to socket %i on special ip for address: %s. exiting.\n", fd,
+			print_ip(address));
 		exit_error("bind socket to node-client-IP failed.");
 	}
 
@@ -173,10 +171,8 @@ void add_special_ip(clientmgr_ctx *ctx, struct client *client) {
 		return;
 
 	if (client->node_ip_initialized) {
-		log_error(
-		    "we already initialized the special client [%s] not doing "
-		    "it again\n",
-		    print_mac(client->mac));
+		log_error("we already initialized the special client [%s] not doing it again\n",
+			  print_mac(client->mac));
 		return;
 	}
 
@@ -253,21 +249,13 @@ void delete_client_ip(struct client *client, const struct in6_addr *address, boo
 /** Adds a route and a neighbour entry
 */
 static void client_add_route(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip) {
-	log_verbose("adding neighbour and route for %s", print_ip(&ip->addr));
 	if (address_is_ipv4(&ip->addr)) {
-		log_verbose(" (IPv4)\n");
-
 		struct in_addr ip4 = extractv4_v6(&ip->addr);
-		log_verbose("Adding neighbor and route for IP: %s\n", print_ip4(&ip4));
+		log_verbose("Adding neighbor and route for IP (IPv4): %s\n", print_ip4(&ip4));
 		routemgr_insert_neighbor4(&l3ctx.routemgr_ctx, client->ifindex, &ip4, client->mac);
-
-		// 		routemgr_insert_neighbor(&l3ctx.routemgr_ctx,
-		// client->ifindex, &ip->addr, client->mac);
-		//		routemgr_insert_route(CTX(routemgr),
-		// ctx->export_table, ctx->nat46ifindex, &ip->addr, 128);
 		routemgr_insert_route4(CTX(routemgr), ctx->export_table, client->ifindex, &ip4, 32);
 	} else {
-		log_verbose(" (IPv6)\n");
+		log_verbose("Adding neighbour and route for IP (IPv6) %s\n", print_ip(&ip->addr));
 		routemgr_insert_neighbor(&l3ctx.routemgr_ctx, client->ifindex, &ip->addr, client->mac);
 		routemgr_insert_route(CTX(routemgr), ctx->export_table, client->ifindex, &ip->addr, 128);
 	}
@@ -278,9 +266,6 @@ static void client_add_route(clientmgr_ctx *ctx, struct client *client, struct c
 static void client_remove_route(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip) {
 	if (address_is_ipv4(&ip->addr)) {
 		struct in_addr ip4 = extractv4_v6(&ip->addr);
-
-		//		routemgr_remove_route(CTX(routemgr),
-		// ctx->export_table, &ip->addr, 128);
 		routemgr_remove_route4(CTX(routemgr), ctx->export_table, &ip4, 32);
 		routemgr_remove_neighbor4(CTX(routemgr), client->ifindex, &ip4, client->mac);
 	} else {
@@ -334,7 +319,7 @@ bool clientmgr_is_known_address(clientmgr_ctx *ctx, const struct in6_addr *addre
 		}
 	}
 
-	log_debug("%s is not assigned to any of the local clients\n", print_ip(address));
+	log_debug("%s is not attached to any of the local clients\n", print_ip(address));
 
 	return false;
 }
@@ -563,6 +548,7 @@ void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client, struct 
 
 void cancel_client_neigh_removal(struct client_ip *ip) {
 	if (ip->removal_task) {
+		log_debug("cancelling ip removal for %s\n", print_ip(&ip->addr));
 		drop_task(ip->removal_task);
 		ip->removal_task = NULL;
 	}

--- a/src/clientmgr.h
+++ b/src/clientmgr.h
@@ -56,31 +56,25 @@ struct client_task {
 	uint8_t mac[ETH_ALEN];
 };
 
-void print_client(struct client *client);
+char *print_client(struct client *client);
 bool clientmgr_valid_address(clientmgr_ctx *ctx, const struct in6_addr *ip);
-void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address,
-			   const uint8_t *mac, const unsigned int ifindex);
-void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client,
-			      struct in6_addr *address);
-void clientmgr_notify_mac(clientmgr_ctx *ctx, uint8_t *mac,
-			  unsigned int ifindex);
-bool clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender,
-			    uint8_t mac[ETH_ALEN]);
+void clientmgr_add_address(clientmgr_ctx *ctx, const struct in6_addr *address, const uint8_t *mac,
+			   const unsigned int ifindex);
+void clientmgr_remove_address(clientmgr_ctx *ctx, struct client *client, struct in6_addr *address);
+void clientmgr_notify_mac(clientmgr_ctx *ctx, uint8_t *mac, unsigned int ifindex);
+bool clientmgr_handle_claim(clientmgr_ctx *ctx, const struct in6_addr *sender, uint8_t mac[ETH_ALEN]);
 bool clientmgr_handle_info(clientmgr_ctx *ctx, struct client *foreign_client);
 void clientmgr_purge_clients(clientmgr_ctx *ctx);
 void clientmgr_delete_client(clientmgr_ctx *ctx, uint8_t mac[ETH_ALEN]);
-void client_ip_set_state(clientmgr_ctx *ctx, struct client *client,
-			 struct client_ip *ip, enum ip_state state);
+void client_ip_set_state(clientmgr_ctx *ctx, struct client *client, struct client_ip *ip, enum ip_state state);
 struct client *get_client(const uint8_t mac[ETH_ALEN]);
-bool clientmgr_is_known_address(clientmgr_ctx *ctx,
-				const struct in6_addr *address,
-				struct client **client);
+bool clientmgr_is_known_address(clientmgr_ctx *ctx, const struct in6_addr *address, struct client **client);
 void add_special_ip(clientmgr_ctx *ctx, struct client *client);
-struct client_ip *get_client_ip(struct client *client,
-				const struct in6_addr *address);
+struct client_ip *get_client_ip(struct client *client, const struct in6_addr *address);
 struct in6_addr mac2ipv6(uint8_t mac[ETH_ALEN], struct prefix *prefix);
 void clientmgr_init();
 bool client_is_active(const struct client *client);
 bool ip_is_active(const struct client_ip *ip);
 
 int client_compare_by_mac(const client_t *a, const client_t *b);
+

--- a/src/clientmgr.h
+++ b/src/clientmgr.h
@@ -40,7 +40,6 @@ typedef struct client {
 } client_t;
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	struct prefix node_client_prefix;
 	struct prefix v4prefix;
 	struct in6_addr platprefix;

--- a/src/clientmgr.h
+++ b/src/clientmgr.h
@@ -7,6 +7,7 @@
 #include "common.h"
 #include "prefix.h"
 #include "vector.h"
+#include "taskqueue.h"
 
 #define OLDCLIENTS_KEEP_SECONDS 5 * 60
 
@@ -24,6 +25,7 @@ struct client_ip {
 	struct timespec timestamp;
 	uint8_t tentative_retries_left;
 	enum ip_state state;
+	taskqueue_t *removal_task;
 };
 
 typedef struct client {

--- a/src/icmp6.c
+++ b/src/icmp6.c
@@ -93,7 +93,7 @@ void icmp6_setup_interface(icmp6_ctx *ctx) {
 		return;
 
 	int rc = setsockopt(ctx->fd, SOL_SOCKET, SO_BINDTODEVICE, ctx->clientif, strnlen(ctx->clientif, IFNAMSIZ - 1));
-	log_verbose("Setting up icmp6 interface: %i\n", rc);
+	log_verbose("Setting up icmp6 interface: %s %i %i %i\n", ctx->clientif, strnlen(ctx->clientif, 12), IFNAMSIZ, rc);
 
 	if (rc < 0) {
 		perror("icmp6 - setsockopt fd:");
@@ -134,7 +134,7 @@ void icmp6_interface_changed(icmp6_ctx *ctx, int type, const struct ifinfomsg *m
 	if (if_indextoname(msg->ifi_index, ifname) == NULL)
 		return;
 
-	if (strcmp(ifname, ctx->clientif) != 0)
+	if (strncmp(ifname, ctx->clientif, IFNAMSIZ - 1) != 0)
 		return;
 
 	log_verbose("icmp6 interface change detected\n");

--- a/src/icmp6.c
+++ b/src/icmp6.c
@@ -279,16 +279,13 @@ void icmp6_handle_in(icmp6_ctx *ctx, int fd) {
 		if (memcmp(packet.hw_addr, "\x00\x00\x00\x00\x00\x00", 6) == 0)
 			continue;
 
-		log_debug(
-		    "Learning from Neighbour Advertisement that Client "
-		    "[%02x:%02x:%02x:%02x:%02x:%02x] is active on ip %s\n",
-		    packet.hw_addr[0], packet.hw_addr[1], packet.hw_addr[2], packet.hw_addr[3], packet.hw_addr[4],
-		    packet.hw_addr[5], print_ip(&packet.hdr.nd_na_target));
+		struct in6_addr addr = packet.hdr.nd_na_target;
+		log_debug("Learning from Neighbour Advertisement that Client [%s] is active on ip %s\n",
+			  print_mac(packet.hw_addr), print_ip(&addr));
 
-		// TODO: make sure to stop possibly previously started NS-cycles
-		// due to DAD,
+		// TODO: stop possibly previously started NS-cycles due to DAD,
 
-		clientmgr_add_address(CTX(clientmgr), &packet.hdr.nd_na_target, packet.hw_addr, ctx->ifindex);
+		clientmgr_add_address(CTX(clientmgr), &addr, packet.hw_addr, ctx->ifindex);
 	}
 }
 

--- a/src/icmp6.c
+++ b/src/icmp6.c
@@ -225,7 +225,7 @@ void icmp6_handle_ns_in(icmp6_ctx *ctx, int fd) {
 									     .tv_sec = 0, .tv_nsec = 300000000,
 									 },
 									 15, true);
-				post_task(CTX(taskqueue), 0, 0, ipmgr_ns_task, free, ns_data);
+				post_task(&l3ctx.taskqueue_ctx, 0, 0, ipmgr_ns_task, free, ns_data);
 			} else {
 				log_debug(
 				    "Received Neighbor Solicitation from %s "
@@ -234,8 +234,8 @@ void icmp6_handle_ns_in(icmp6_ctx *ctx, int fd) {
 				    print_ip(&packet.hdr.ip6_src), print_mac(mac),
 				    print_ip(&packet.sol.hdr.nd_ns_target));
 
-				clientmgr_notify_mac(CTX(clientmgr), mac, ctx->ifindex);
-				clientmgr_add_address(CTX(clientmgr), &packet.hdr.ip6_src, mac, ctx->ifindex);
+				clientmgr_notify_mac(&l3ctx.clientmgr_ctx, mac, ctx->ifindex);
+				clientmgr_add_address(&l3ctx.clientmgr_ctx, &ip6_src, mac, ctx->ifindex);
 			}
 		}
 	}
@@ -285,7 +285,7 @@ void icmp6_handle_in(icmp6_ctx *ctx, int fd) {
 
 		// TODO: stop possibly previously started NS-cycles due to DAD,
 
-		clientmgr_add_address(CTX(clientmgr), &addr, packet.hw_addr, ctx->ifindex);
+		clientmgr_add_address(&l3ctx.clientmgr_ctx, &addr, packet.hw_addr, ctx->ifindex);
 	}
 }
 

--- a/src/icmp6.h
+++ b/src/icmp6.h
@@ -8,7 +8,6 @@
 #include "ipmgr.h"
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	char *clientif;
 	int fd;  // used to learn addresses from NA and send solicitations
 	int unreachfd6;  // used to send ICMP6 destination unreachable

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -705,27 +705,19 @@ void claim_retry_task(void *d) {
 	int repeatable_claim_index;
 	if (!find_repeatable(&l3ctx.intercom_ctx.repeatable_claims, data->client, &repeatable_claim_index)) {
 		log_debug(
-		    "could not find repeatable claim for client [%s]. This "
-		    "happens when an INFO packet was received before all claim "
-		    "retry-cycles are spent OR when deleting the client. Returning.\n",
+		    "could not find repeatable claim for client [%s]. This happens when an INFO packet was received "
+		    "before all claim retry-cycles are spent OR when deleting the client. Returning.\n",
 		    print_mac(data->client->mac));
 		return;
 	}
 
 	if (data->recipient != NULL) {
-		log_debug(
-		    "sending unicast claim for client "
-		    "%02x:%02x:%02x:%02x:%02x:%02x to %s\n",
-		    data->client->mac[0], data->client->mac[1], data->client->mac[2], data->client->mac[3],
-		    data->client->mac[4], data->client->mac[5], print_ip(data->recipient));
+		log_debug("sending unicast claim for client %s to %s\n", print_mac(data->client->mac),
+			  print_ip(data->recipient));
 		unicast_packet_sent = intercom_send_packet_unicast(&l3ctx.intercom_ctx, data->recipient,
 								   (uint8_t *)data->packet, data->packet_len);
 	} else {
-		log_debug(
-		    "sending multicast claim for client "
-		    "%02x:%02x:%02x:%02x:%02x:%02x\n",
-		    data->client->mac[0], data->client->mac[1], data->client->mac[2], data->client->mac[3],
-		    data->client->mac[4], data->client->mac[5]);
+		log_debug("sending multicast claim for client %s\n", print_mac(data->client->mac));
 		intercom_recently_seen_add(&l3ctx.intercom_ctx, &((intercom_packet_claim *)data->packet)->hdr);
 		intercom_send_packet(&l3ctx.intercom_ctx, (uint8_t *)&data->packet, data->packet_len);
 	}
@@ -735,7 +727,7 @@ void claim_retry_task(void *d) {
 	else {
 		// we have not received an info message or sending a unicast
 		// claim was not successful
-		// the only valid business reason for this to happens is when
+		// the only valid reason for this to happen is when
 		// there is no route to the client, so it must be new to the
 		// network
 		// TODO: what about EINTR EWOULDBLOCK ENOBUFS ENOMEM

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -398,9 +398,9 @@ bool intercom_handle_seek(intercom_ctx *ctx, intercom_packet_seek *packet, int p
 				printf("\x1b[36mSEEK: Looking for %s\x1b[0m\n", print_ip(&address));
 
 				if (address_is_ipv4(&address))
-					arp_send_request(CTX(arp), &address);
+					arp_send_request(&l3ctx.arp_ctx, &address);
 				else
-					icmp6_send_solicitation(CTX(icmp6), &address);
+					icmp6_send_solicitation(&l3ctx.icmp6_ctx, &address);
 				break;
 			default:
 				log_error(
@@ -447,7 +447,7 @@ bool intercom_handle_claim(intercom_ctx *ctx, intercom_packet_claim *packet, int
 		}
 	}
 
-	return !clientmgr_handle_claim(CTX(clientmgr), &sender, claim.mac);
+	return !clientmgr_handle_claim(&l3ctx.clientmgr_ctx, &sender, claim.mac);
 }
 
 /* find an entry in a vector containing elements of type client_t */
@@ -545,7 +545,7 @@ bool intercom_handle_info(intercom_ctx *ctx, intercom_packet_info *packet, int p
 
 	intercom_remove_claim(ctx, &client);
 
-	bool acted_on_local_client = clientmgr_handle_info(CTX(clientmgr), &client);
+	bool acted_on_local_client = clientmgr_handle_info(&l3ctx.clientmgr_ctx, &client);
 	intercom_ack(ctx, &sender, &client);
 	VECTOR_FREE(client.addresses);
 	return !acted_on_local_client;

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -254,10 +254,7 @@ uint8_t assemble_basicinfo(uint8_t *packet, struct client *client) {
 		}
 	}
 
-	if (l3ctx.debug) {
-		log_debug("added %i addresses to info packet for client ", num_addresses);
-		print_client(client);
-	}
+	log_debug("added %i addresses to info packet for client \n%s\n", num_addresses, print_client(client));
 
 	// fill length field
 	packet[1] = num_addresses * sizeof(intercom_packet_info_entry) + sizeof(client->mac) + 2;
@@ -360,10 +357,7 @@ int parse_basic(const uint8_t *packet, struct client *client) {
 	uint8_t length = packet[1];
 	int num_addresses = (length - 2 - 6) / 16;
 
-	if (l3ctx.debug) {
-		log_debug("handling info segment with %i addresses for client ", num_addresses);
-		print_client(client);
-	}
+	log_debug("handling info segment with %i addresses for client %s\n", num_addresses, print_client(client));
 
 	struct client_ip ip = {};
 	ip.state = IP_INACTIVE;

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -92,7 +92,7 @@ intercom_if_t *intercom_has_ifname(intercom_ctx *ctx, const char *ifname, int *e
 }
 
 bool intercom_add_interface(intercom_ctx *ctx, char *ifname) {
-	if (intercom_has_ifname(ctx, ifname, NULL))
+	if (!ifname || intercom_has_ifname(ctx, ifname, NULL))
 		return false;
 
 	int ifindex = if_nametoindex(ifname);

--- a/src/intercom.c
+++ b/src/intercom.c
@@ -365,7 +365,7 @@ int parse_basic(const uint8_t *packet, struct client *client) {
 		print_client(client);
 	}
 
-	struct client_ip ip = {0};
+	struct client_ip ip = {};
 	ip.state = IP_INACTIVE;
 
 	intercom_packet_info_entry *entry = (intercom_packet_info_entry *)(packet + 8);
@@ -515,7 +515,7 @@ bool intercom_handle_ack(intercom_ctx *ctx, intercom_packet_ack *packet, int pac
 
 bool intercom_handle_info(intercom_ctx *ctx, intercom_packet_info *packet, int packet_len) {
 	uint8_t type, *packetpointer;
-	struct client client = {0};
+	struct client client = {};
 	int currentoffset = sizeof(intercom_packet_info);
 	struct in6_addr sender;
 

--- a/src/intercom.h
+++ b/src/intercom.h
@@ -101,7 +101,6 @@ struct intercom_task {
 typedef struct {
 	struct in6_addr ip;
 	struct sockaddr_in6 groupaddr;
-	struct l3ctx *l3ctx;
 	VECTOR(intercom_packet_hdr) recent_packets;
 	intercom_if_v interfaces;
 	client_v repeatable_claims;

--- a/src/ipmgr.c
+++ b/src/ipmgr.c
@@ -86,12 +86,12 @@ void ipmgr_seek_address(ipmgr_ctx *ctx, struct in6_addr *addr) {
 	    .tv_sec = SEEK_INTERVAL, .tv_nsec = 0,
 	};
 	struct ns_task *ns_data = create_ns_task(addr, interval, -1, false);
-	post_task(CTX(taskqueue), 0, 0, ipmgr_ns_task, free, ns_data);
+	post_task(&l3ctx.taskqueue_ctx, 0, 0, ipmgr_ns_task, free, ns_data);
 
 	// schedule an intercom-seek operation that in turn will only be
 	// executed if there is no local client known
 	struct ip_task *data = create_task(addr);
-	post_task(CTX(taskqueue), 0, 300, seek_task, free, data);
+	post_task(&l3ctx.taskqueue_ctx, 0, 300, seek_task, free, data);
 }
 
 static bool ismulticast(const struct in6_addr *addr) {
@@ -111,7 +111,7 @@ static void handle_packet(ipmgr_ctx *ctx, uint8_t packet[], ssize_t packet_len) 
 	if (ismulticast(&dst))
 		return;
 
-	if (!clientmgr_valid_address(CTX(clientmgr), &dst)) {
+	if (!clientmgr_valid_address(&l3ctx.clientmgr_ctx, &dst)) {
 		log_verbose(
 		    "The destination of the packet (%s) is not within the "
 		    "client prefixes. Ignoring packet\n",

--- a/src/ipmgr.c
+++ b/src/ipmgr.c
@@ -309,28 +309,18 @@ void ipmgr_handle_out(ipmgr_ctx *ctx, int fd) {
 		// TODO: handle ipv4 packets correctly
 		if (write(fd, packet->data, packet->len) == -1) {
 			if (errno != EAGAIN)
-				perror(
-				    "Could not send packet to newly visible "
-				    "client, discarding this packet.");
+				perror("Could not send packet to newly visible client, discarding this packet.");
 			else {
 				clock_gettime(CLOCK_MONOTONIC, &now);
 				then = now;
 				then.tv_sec -= PACKET_TIMEOUT;
-				perror(
-				    "Could not send packet to newly visible "
-				    "client.");
+				perror("Could not send packet to newly visible client.");
 				if (timespec_cmp(packet->timestamp, then) <= 0) {
-					log_error(
-					    "could not send packet - packet is "
-					    "still young enough, requeueing\n");
-					// TODO: consider if output_queue
-					// really is the correct queue when
-					// requeueing
+					log_error("could not send packet - packet is still young enough, requeueing\n");
+					// TODO: consider if output_queue really is the correct queue when requeueing
 					VECTOR_ADD(ctx->output_queue, *packet);
 				} else {
-					log_error(
-					    "could not send packet - packet is "
-					    "too old, discarding.\n");
+					log_error("could not send packet - packet is too old, discarding.\n");
 				}
 			}
 

--- a/src/ipmgr.h
+++ b/src/ipmgr.h
@@ -44,7 +44,6 @@ struct unknown_address {
 };
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	char *ifname;
 	VECTOR(struct unknown_address) addrs;
 	VECTOR(struct packet) output_queue;

--- a/src/l3roamd.h
+++ b/src/l3roamd.h
@@ -43,4 +43,3 @@ void add_fd(int efd, int fd, uint32_t events);
 void del_fd(int efd, int fd);
 
 #define INTERCOM_PORT 5523
-#define CTX(tgt) (&ctx->l3ctx->tgt##_ctx)

--- a/src/main.c
+++ b/src/main.c
@@ -345,6 +345,7 @@ void usage() {
 	puts(
 	    "probe <addr> <mac>       This will start a neighbour discovery "
 	    "for a neighbour <mac> with address <addr>");
+	puts("verbosity <none|verbose|debug>	This will set the verbosity of the l3roamd process");
 }
 
 void catch_sigterm() {

--- a/src/main.c
+++ b/src/main.c
@@ -150,11 +150,11 @@ void loop() {
 	add_fd(efd, l3ctx.taskqueue_ctx.fd, EPOLLIN);
 
 	if (l3ctx.clientif_set) {
-		printf("adding icmp6-fd to epoll\n");
+		log_verbose("adding icmp6-fd to epoll\n");
 		add_fd(efd, l3ctx.icmp6_ctx.fd, EPOLLIN);
 		add_fd(efd, l3ctx.icmp6_ctx.nsfd, EPOLLIN);
 
-		printf("adding arp-fd to epoll\n");
+		log_verbose("adding arp-fd to epoll\n");
 		add_fd(efd, l3ctx.arp_ctx.fd, EPOLLIN);
 
 		if (l3ctx.wifistations_ctx.fd >= 0)
@@ -417,12 +417,10 @@ int main(int argc, char *argv[]) {
 				exit(EXIT_SUCCESS);
 			case 'a':
 				if (a_initialized)
-					exit_error(
-					    "-a must not be specified more "
-					    "than once");
+					exit_error("-a must not be specified more than once");
 
 				if (inet_pton(AF_INET6, optarg, &l3ctx.intercom_ctx.ip) != 1)
-					exit_error("Can not parse IP address");
+					exit_error("Can not parse IP address %s\n", optarg);
 				intercom_init_unicast(&l3ctx.intercom_ctx);
 				a_initialized = true;
 				break;
@@ -431,27 +429,22 @@ int main(int argc, char *argv[]) {
 				parse_config(optarg);
 				break;
 			case 'P':;
-				printf("parsing prefix %s\n", optarg);
 				struct prefix _ncprefix = {};
 				if (!parse_prefix(&_ncprefix, optarg))
-					exit_error(
-					    "Can not parse node-client-prefix "
-					    "that passed by -P");
+					exit_error("Can not parse node-client-prefix that passed by -P %s\n", optarg);
 				l3ctx.clientmgr_ctx.node_client_prefix = _ncprefix;
 				break;
 			case 'p': {
 				struct prefix _prefix = {};
-				if (!parse_prefix(&_prefix, optarg)) {
-					fprintf(stderr, "prefix: %s - ", optarg);
-					exit_error("Can not parse prefix");
-				}
+				if (!parse_prefix(&_prefix, optarg))
+					exit_error("Can not parse prefix %s\n", optarg);
 				add_prefix(&l3ctx.clientmgr_ctx.prefixes, _prefix);
 				p_initialized = true;
 			} break;
 			case 'e': {
 				struct prefix _prefix = {};
 				if (!parse_prefix(&_prefix, optarg))
-					exit_error("Can not parse PLAT-prefix");
+					exit_error("Can not parse PLAT-prefix %s\n", optarg);
 				if (_prefix.plen != 96)
 					exit_error("PLAT-prefix must be /96");
 
@@ -480,12 +473,8 @@ int main(int argc, char *argv[]) {
 					l3ctx.clientif_set = true;
 				} else {
 					fprintf(stderr,
-						"ignoring unknown "
-						"client-interface %s or "
-						"client-interface was already "
-						"set. Only the first "
-						"client-interface will be "
-						"considered.\n",
+						"ignoring unknown client-interface %s or client-interface was already "
+						"set. Only the first client-interface will be considered.\n",
 						optarg);
 				}
 				break;

--- a/src/main.c
+++ b/src/main.c
@@ -363,16 +363,6 @@ int main(int argc, char *argv[]) {
 
 	signal(SIGPIPE, SIG_IGN);
 
-	l3ctx.wifistations_ctx.l3ctx = &l3ctx;
-	l3ctx.clientmgr_ctx.l3ctx = &l3ctx;
-	l3ctx.intercom_ctx.l3ctx = &l3ctx;
-	l3ctx.ipmgr_ctx.l3ctx = &l3ctx;
-	l3ctx.routemgr_ctx.l3ctx = &l3ctx;
-	l3ctx.socket_ctx.l3ctx = &l3ctx;
-	l3ctx.taskqueue_ctx.l3ctx = &l3ctx;
-	l3ctx.icmp6_ctx.l3ctx = &l3ctx;
-	l3ctx.arp_ctx.l3ctx = &l3ctx;
-
 	l3ctx.client_mtu = 1500;
 	l3ctx.intercom_ctx.mtu = 1500;
 

--- a/src/prefix.c
+++ b/src/prefix.c
@@ -96,7 +96,7 @@ bool del_prefix(void *prefixes, struct prefix _prefix) {
 }
 
 bool prefix_contains(const struct prefix *prefix, const struct in6_addr *addr) {
-	log_debug("checking if prefix %s contains address %s\n", print_ip(&prefix->prefix), print_ip(addr));
+//	log_debug("checking if prefix %s contains address %s\n", print_ip(&prefix->prefix), print_ip(addr));
 
 	int mask = 0xff;
 	for (int remaining_plen = prefix->plen, i = 0; remaining_plen > 0; remaining_plen -= 8) {

--- a/src/prefix.c
+++ b/src/prefix.c
@@ -31,43 +31,38 @@
 /* this will parse the string str and return a prefix struct
 */
 bool parse_prefix(struct prefix *prefix, const char *str) {
-	char *saveptr;
-	char *tmp = strdup(str);
+	char *saveptr = NULL;
+	char tmp[INET6_ADDRSTRLEN + 5]; // hold complete prefix + "/" + 3-digit prefix length + terminating null-byte
+	strncpy(tmp, str, INET6_ADDRSTRLEN + 5);
 
-	prefix->isv4 = true;
-	if (strchr(tmp, ':'))
-		prefix->isv4 = false;
+	prefix->isv4 = !strchr(tmp, ':');
 
-	log_debug("parsing prefix %s, ipv4-state: %i\n", str, prefix->isv4);
-
+	log_debug("parsing %s prefix: %s\n", prefix->isv4 ? "IPv4" : "IPv6", str);
 	char *ptr = strtok_r(tmp, "/", &saveptr);
+	if (!ptr)
+		return false;
 
 	if (prefix->isv4) {
 		struct in_addr v4;
 		if (inet_pton(AF_INET, ptr, &v4) != 1)
-			goto error;
+			return false;
 		mapv4_v6(&v4, &prefix->prefix);
 	} else {
 		if (inet_pton(AF_INET6, ptr, &prefix->prefix) != 1)
-			goto error;
+			return false;
 	}
 	ptr = strtok_r(NULL, "/", &saveptr);
-	if (ptr == NULL)
-		goto error;
+	if (!ptr)
+		return false;
 
 	prefix->plen = atoi(ptr);
 	if (prefix->isv4)
 		prefix->plen += 96;
 
 	if (prefix->plen < 0 || prefix->plen > 128)
-		goto error;
+		return false;
 
-	free(tmp);
 	return true;
-
-error:
-	free(tmp);
-	return false;
 }
 
 /* this will add a prefix to the prefix vector, causing l3roamd  to

--- a/src/routemgr.c
+++ b/src/routemgr.c
@@ -45,7 +45,7 @@ void rtmgr_client_probe_addresses(struct client *client) {
 
 void rtmgr_client_remove_address(struct in6_addr *dst_address) {
 	struct client *_client = NULL;
-	log_debug("attempting to remove address %s\n", print_ip(dst_address));
+	log_debug("removing address %s\n", print_ip(dst_address));
 	if (clientmgr_is_known_address(&l3ctx.clientmgr_ctx, dst_address, &_client)) {
 		log_debug("removing address %s from client [%s]\n", print_ip(dst_address), print_mac(_client->mac));
 		clientmgr_remove_address(&l3ctx.clientmgr_ctx, _client, dst_address);
@@ -252,10 +252,7 @@ void rtnl_handle_msg(routemgr_ctx *ctx, const struct nlmsghdr *nh) {
 			rtnl_handle_link(nh);
 			break;
 		default:
-			log_debug(
-			    "not handling unknown netlink message with type: "
-			    "%i\n",
-			    nh->nlmsg_type);
+			log_debug("not handling unknown netlink message with type: %i\n", nh->nlmsg_type);
 			return;
 	}
 }
@@ -389,8 +386,7 @@ int parse_kernel_route_rta(struct rtmsg *rtm, int len, struct kernel_route *rout
 }
 
 void routemgr_handle_in(routemgr_ctx *ctx, int fd) {
-	if (l3ctx.debug)
-		printf("handling routemgr_in event ");
+	log_debug("handling routemgr_in event ");
 	ssize_t count;
 	uint8_t readbuffer[8192];
 
@@ -407,11 +403,8 @@ void routemgr_handle_in(routemgr_ctx *ctx, int fd) {
 			break;  // TODO: shouldn't we re-open the fd in this
 				// case?
 
-		if (l3ctx.debug)
-			printf(
-			    "read %zi Bytes from netlink socket, "
-			    "readbuffer-size is %zi, ... parsing data now.\n",
-			    count, sizeof(readbuffer));
+		log_debug("read %zi Bytes from netlink socket, readbuffer-size is %zi, ... parsing data now.\n", count,
+			  sizeof(readbuffer));
 
 		nh = (struct nlmsghdr *)readbuffer;
 		if (NLMSG_OK(nh, count)) {

--- a/src/routemgr.c
+++ b/src/routemgr.c
@@ -231,7 +231,7 @@ void handle_kernel_routes(routemgr_ctx *ctx, const struct nlmsghdr *nh) {
 }
 
 void rtnl_handle_msg(routemgr_ctx *ctx, const struct nlmsghdr *nh) {
-	if (ctx->nl_disabled)
+	if (!nh || ctx->nl_disabled)
 		return;
 
 	switch (nh->nlmsg_type) {
@@ -335,19 +335,17 @@ int parse_kernel_route_rta(struct rtmsg *rtm, int len, struct kernel_route *rout
 	for (struct rtattr *rta = RTM_RTA(rtm); RTA_OK(rta, len); rta = RTA_NEXT(rta, len)) {
 		switch (rta->rta_type) {
 			case RTA_DST:
-
 				if (rtm->rtm_family == AF_INET6) {
 					route->plen = rtm->rtm_dst_len;
 					memcpy(route->prefix.s6_addr, RTA_DATA(rta), 16);
-					log_debug("parsed route, found dst: %s\n", print_ip(&route->prefix));
 
 				} else if (rtm->rtm_family == AF_INET) {
 					struct in_addr ipv4;
 					memcpy(&ipv4.s_addr, RTA_DATA(rta), 4);
 					mapv4_v6(&ipv4, &route->prefix);
 					route->plen = rtm->rtm_dst_len + 96;
-					log_debug("parsed route, found dst: %s\n", print_ip(&route->prefix));
 				}
+				log_debug("parsed route, found dst: %s\n", print_ip(&route->prefix));
 				break;
 			case RTA_SRC:
 				if (rtm->rtm_family == AF_INET6) {

--- a/src/routemgr.c
+++ b/src/routemgr.c
@@ -173,8 +173,7 @@ void client_bridge_changed(const struct nlmsghdr *nh, const struct ifinfomsg *ms
 
 			case RTM_DELLINK:
 				log_verbose(
-				    "del link on %i, fdb-entry was removed for "
-				    "[%s].\n",
+				    "del link on %i, fdb-entry was removed for [%s].\n",
 				    msg->ifi_index, print_mac(RTA_DATA(tb[IFLA_ADDRESS])));
 				clientmgr_delete_client(&l3ctx.clientmgr_ctx, RTA_DATA(tb[IFLA_ADDRESS]));
 				break;

--- a/src/routemgr.h
+++ b/src/routemgr.h
@@ -44,7 +44,6 @@ struct kernel_route {
 };
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	char *clientif;
 	char *client_bridge;
 	int fd;

--- a/src/socket.c
+++ b/src/socket.c
@@ -79,6 +79,8 @@ void socket_init(socket_ctx *ctx, char *path) {
 bool parse_command(char *cmd, enum socket_command *scmd) {
 	if (!strncmp(cmd, "get_clients", 11))
 		*scmd = GET_CLIENTS;
+	else if (!strncmp(cmd, "verbosity ", 10))
+		*scmd = SET_VERBOSITY;
 	else if (!strncmp(cmd, "del_meshif ", 11))
 		*scmd = DEL_MESHIF;
 	else if (!strncmp(cmd, "get_meshifs", 11))
@@ -202,6 +204,7 @@ void socket_handle_in(socket_ctx *ctx) {
 	char *str_address = NULL;
 	char *str_mac = NULL;
 	char *str_meshif = NULL;
+	char *verbosity = NULL;
 
 	switch (cmd) {
 		case PROBE:
@@ -225,6 +228,21 @@ void socket_handle_in(socket_ctx *ctx) {
 						      (struct in6_addr *)(_prefix.prefix.s6_addr), _prefix.plen);
 				dprintf(fd, "Added prefix: %s", &line[11]);
 			}
+			break;
+		case SET_VERBOSITY:
+			verbosity = strtok(&line[10], " ");
+
+			if (!strncmp(verbosity, "none", 4)) {
+				l3ctx.verbose = false;
+				l3ctx.debug = false;
+			} else if (!strncmp(verbosity, "verbose", 7)) {
+				l3ctx.verbose = true;
+				l3ctx.debug = false;
+			} else if (!strncmp(verbosity, "debug", 5)) {
+				l3ctx.verbose = true;
+				l3ctx.debug = true;
+			}
+
 			break;
 		case ADD_ADDRESS:
 			str_address = strtok(&line[12], " ");

--- a/src/socket.c
+++ b/src/socket.c
@@ -223,8 +223,8 @@ void socket_handle_in(socket_ctx *ctx) {
 			break;
 		case ADD_PREFIX:
 			if (parse_prefix(&_prefix, &line[11])) {
-				add_prefix(&CTX(clientmgr)->prefixes, _prefix);
-				routemgr_insert_route(CTX(routemgr), 254, if_nametoindex(CTX(ipmgr)->ifname),
+				add_prefix(&l3ctx.clientmgr_ctx.prefixes, _prefix);
+				routemgr_insert_route(&l3ctx.routemgr_ctx, 254, if_nametoindex(l3ctx.ipmgr_ctx.ifname),
 						      (struct in6_addr *)(_prefix.prefix.s6_addr), _prefix.plen);
 				dprintf(fd, "Added prefix: %s", &line[11]);
 			}
@@ -297,8 +297,8 @@ void socket_handle_in(socket_ctx *ctx) {
 			break;
 		case DEL_PREFIX:
 			if (parse_prefix(&_prefix, &line[11])) {
-				del_prefix(&CTX(clientmgr)->prefixes, _prefix);
-				routemgr_remove_route(CTX(routemgr), 254, (struct in6_addr *)(_prefix.prefix.s6_addr),
+				del_prefix(&l3ctx.clientmgr_ctx.prefixes, _prefix);
+				routemgr_remove_route(&l3ctx.routemgr_ctx, 254, (struct in6_addr *)(_prefix.prefix.s6_addr),
 						      _prefix.plen);
 				dprintf(fd, "Deleted prefix: %s", &line[11]);
 			}

--- a/src/socket.h
+++ b/src/socket.h
@@ -24,7 +24,6 @@ enum socket_command {
 };
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	int fd;
 } socket_ctx;
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -19,7 +19,8 @@ enum socket_command {
 	DEL_PREFIX,
 	GET_PREFIX,
 	ADD_ADDRESS,
-	DEL_ADDRESS
+	DEL_ADDRESS,
+	SET_VERBOSITY
 };
 
 typedef struct {

--- a/src/taskqueue.c
+++ b/src/taskqueue.c
@@ -43,7 +43,7 @@ void taskqueue_init(taskqueue_ctx *ctx) {
 
 /** this will add timeout seconds and millisecs milliseconds to the current time
  * to calculate at which time a task should run given an offset */
-struct timespec settime(unsigned int timeout, unsigned int millisecs) {
+struct timespec settime(time_t timeout, long millisecs) {
 	struct timespec due;
 	clock_gettime(CLOCK_MONOTONIC, &due);
 
@@ -54,7 +54,7 @@ struct timespec settime(unsigned int timeout, unsigned int millisecs) {
 
 /** Enqueues a new task. A task with a timeout of zero is scheduled immediately.
  */
-taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout, unsigned int millisecs, void (*function)(void *),
+taskqueue_t *post_task(taskqueue_ctx *ctx, time_t timeout, long millisecs, void (*function)(void *),
 		       void (*cleanup)(void *), void *data) {
 	taskqueue_t *task = l3roamd_alloc(sizeof(taskqueue_t));
 	task->children = task->next = NULL;
@@ -82,7 +82,7 @@ void drop_task(taskqueue_t *task) {
 
 /** Changes the timeout of a task.
   */
-bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task, unsigned int timeout, unsigned int millisecs) {
+bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task, time_t timeout, long millisecs) {
 	if (task == NULL || !taskqueue_linked(task))
 		return false;
 

--- a/src/taskqueue.c
+++ b/src/taskqueue.c
@@ -71,6 +71,15 @@ taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout, unsigned int mi
 	return task;
 }
 
+void drop_task(taskqueue_t *task) {
+	taskqueue_remove(task);
+
+	if (task->cleanup != NULL)
+		task->cleanup(task->data);
+
+	free(task);
+}
+
 /** Changes the timeout of a task.
   */
 bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task, unsigned int timeout, unsigned int millisecs) {

--- a/src/taskqueue.c
+++ b/src/taskqueue.c
@@ -99,40 +99,47 @@ bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task, time_t timeout, long
 }
 
 void taskqueue_schedule(taskqueue_ctx *ctx) {
-	if (ctx->queue == NULL)
+	if (ctx->queue == NULL) {
+		log_debug("Taskqueue is empty, not scheduling another task\n");
 		return;
+	}
 
 	struct itimerspec t = {.it_value = ctx->queue->due};
+	struct timespec now;
+	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	timerfd_settime(ctx->fd, TFD_TIMER_ABSTIME, &t, NULL);
+	if (timespec_cmp(ctx->queue->due, now) <= 0)
+		taskqueue_run(ctx);
+	else {
+		log_debug("It is now: %s, scheduling next task for %s\n", print_timespec(&now), print_timespec(&ctx->queue->due));
+		timerfd_settime(ctx->fd, TFD_TIMER_ABSTIME, &t, NULL);
+	}
 }
 
 void taskqueue_run(taskqueue_ctx *ctx) {
-	log_debug("handling taskqueue event\n");
 	unsigned long long nEvents;
 
 	struct timespec now;
 	clock_gettime(CLOCK_MONOTONIC, &now);
 
-	read(ctx->fd, &nEvents, sizeof(nEvents));
+	size_t rsize = read(ctx->fd, &nEvents, sizeof(nEvents));
+	if ( ! rsize)
+		log_error("could not read from taskqueue fd\n");
 
 	if (ctx->queue == NULL)
 		return;
 
-	taskqueue_t *task = NULL;
-	do {
-		task = ctx->queue;
+	while (ctx->queue && timespec_cmp(ctx->queue->due, now) <= 0) {
+		taskqueue_t *task = ctx->queue;
+		log_debug("The time is now: %s, running task that was due at %s\n", print_timespec(&now), print_timespec(&task->due));
+		taskqueue_remove(task);
+		task->function(task->data);
 
-		if (timespec_cmp(task->due, now) <= 0) {
-			taskqueue_remove(task);
-			task->function(task->data);
+		if (task->cleanup)
+			task->cleanup(task->data);
 
-			if (task->cleanup != NULL)
-				task->cleanup(task->data);
-
-			free(task);
-		}
-	} while (timespec_cmp(task->due, now) <= 0);
+		free(task);
+	}
 
 	taskqueue_schedule(ctx);
 }

--- a/src/taskqueue.c
+++ b/src/taskqueue.c
@@ -119,17 +119,20 @@ void taskqueue_run(taskqueue_ctx *ctx) {
 	if (ctx->queue == NULL)
 		return;
 
-	taskqueue_t *task = ctx->queue;
+	taskqueue_t *task = NULL;
+	do {
+		task = ctx->queue;
 
-	if (timespec_cmp(task->due, now) <= 0) {
-		taskqueue_remove(task);
-		task->function(task->data);
+		if (timespec_cmp(task->due, now) <= 0) {
+			taskqueue_remove(task);
+			task->function(task->data);
 
-		if (task->cleanup != NULL)
-			task->cleanup(task->data);
+			if (task->cleanup != NULL)
+				task->cleanup(task->data);
 
-		free(task);
-	}
+			free(task);
+		}
+	} while (timespec_cmp(task->due, now) <= 0);
 
 	taskqueue_schedule(ctx);
 }

--- a/src/taskqueue.h
+++ b/src/taskqueue.h
@@ -6,7 +6,6 @@
 typedef struct taskqueue taskqueue_t;
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	taskqueue_t *queue;
 	int fd;
 } taskqueue_ctx;

--- a/src/taskqueue.h
+++ b/src/taskqueue.h
@@ -38,5 +38,6 @@ void taskqueue_schedule(taskqueue_ctx *ctx);
 taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout,
 		       unsigned int millisecs, void (*function)(void *),
 		       void (*cleanup)(void *), void *data);
+void drop_task(taskqueue_t *task);
 bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task,
 		     unsigned int timeout, unsigned int millisecs);

--- a/src/taskqueue.h
+++ b/src/taskqueue.h
@@ -35,9 +35,9 @@ void taskqueue_remove(taskqueue_t *elem);
 void taskqueue_init(taskqueue_ctx *ctx);
 void taskqueue_run(taskqueue_ctx *ctx);
 void taskqueue_schedule(taskqueue_ctx *ctx);
-taskqueue_t *post_task(taskqueue_ctx *ctx, unsigned int timeout,
-		       unsigned int millisecs, void (*function)(void *),
+taskqueue_t *post_task(taskqueue_ctx *ctx, time_t timeout,
+		       long millisecs, void (*function)(void *),
 		       void (*cleanup)(void *), void *data);
 void drop_task(taskqueue_t *task);
 bool reschedule_task(taskqueue_ctx *ctx, taskqueue_t *task,
-		     unsigned int timeout, unsigned int millisecs);
+		     time_t timeout, long millisecs);

--- a/src/test.c
+++ b/src/test.c
@@ -139,8 +139,6 @@ int test_icmp_dest_unreachable4() {
 	l3ctx.clientif_set = true;
 	l3ctx.icmp6_ctx.clientif = strdupa("tst1");
 
-	l3ctx.icmp6_ctx.l3ctx = &l3ctx;
-
 	icmp6_init(&l3ctx.icmp6_ctx);
 
 	return icmp_send_dest_unreachable(&addr, &data);

--- a/src/timespec.c
+++ b/src/timespec.c
@@ -2,7 +2,7 @@
 
 #define BILLION 1000000000l
 struct timespec timeAdd(struct timespec *t1, struct timespec *t2) {
-	long sec = t2->tv_sec + t1->tv_sec;
+	time_t sec = t2->tv_sec + t1->tv_sec;
 	long nsec = t2->tv_nsec + t1->tv_nsec;
 	if (nsec >= BILLION) {
 		nsec -= BILLION;

--- a/src/util.c
+++ b/src/util.c
@@ -7,29 +7,35 @@
 #include "error.h"
 #include "l3roamd.h"
 
-#define STRBUFELEMENTS 3
-#define STRBUFLEN (INET6_ADDRSTRLEN)
 
-static char strbuffer[STRBUFELEMENTS][STRBUFLEN + 1];
+union buffer strbuffer;
 static int str_bufferoffset = 0;
 
 const char *print_ip4(const struct in_addr *addr) {
 	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
-	return inet_ntop(AF_INET, &(addr->s_addr), strbuffer[str_bufferoffset], STRBUFLEN);
+	return inet_ntop(AF_INET, &(addr->s_addr), strbuffer.element[str_bufferoffset], STRBUFELEMENTLEN);
+}
+
+/** print a timespec to buffer
+*/
+const char *print_timespec(const struct timespec *t) {
+	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
+	snprintf(strbuffer.element[str_bufferoffset], STRBUFELEMENTLEN, "%lu.%09lu", t->tv_sec, t->tv_nsec);
+	return strbuffer.element[str_bufferoffset];
 }
 
 /* print a human-readable representation of an in6_addr struct to stdout
 ** */
 const char *print_ip(const struct in6_addr *addr) {
 	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
-	return inet_ntop(AF_INET6, &(addr->s6_addr), strbuffer[str_bufferoffset], STRBUFLEN);
+	return inet_ntop(AF_INET6, &(addr->s6_addr), strbuffer.element[str_bufferoffset], STRBUFELEMENTLEN);
 }
 
 const char *print_mac(const uint8_t *mac) {
 	str_bufferoffset = (str_bufferoffset + 1) % STRBUFELEMENTS;
-	snprintf(strbuffer[str_bufferoffset], STRBUFLEN, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", mac[0], mac[1], mac[2],
+	snprintf(strbuffer.element[str_bufferoffset], STRBUFELEMENTLEN, "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx", mac[0], mac[1], mac[2],
 		 mac[3], mac[4], mac[5]);
-	return strbuffer[str_bufferoffset];
+	return strbuffer.element[str_bufferoffset];
 }
 
 struct in_addr inline extractv4_v6(const struct in6_addr *src) {

--- a/src/util.h
+++ b/src/util.h
@@ -3,11 +3,21 @@
 #include <netinet/in.h>
 #include <stdbool.h>
 
+#define STRBUFELEMENTLEN 64
+#define STRBUFLEN 256
+#define STRBUFELEMENTS (STRBUFLEN / STRBUFELEMENTLEN)
+
+union buffer {
+	char element[STRBUFLEN / STRBUFELEMENTLEN][STRBUFELEMENTLEN];
+	char allofit[STRBUFLEN];
+};
+
 struct in_addr extractv4_v6(const struct in6_addr *src);
 void mapv4_v6(const struct in_addr *src, struct in6_addr *dst);
 const char *print_ip4(const struct in_addr *addr);
 const char *print_ip(const struct in6_addr *addr);
 const char *print_mac(const uint8_t *mac);
+const char *print_timespec(const struct timespec *t);
 void log_verbose(const char *format, ...);
 void log_debug(const char *format, ...);
 void log_error(const char *format, ...);

--- a/src/wifistations.c
+++ b/src/wifistations.c
@@ -55,15 +55,15 @@ int wifistations_handle_event(struct nl_msg *msg, void *arg) {
 		case NL80211_CMD_NEW_STATION:
 			log_verbose("new wifi station [%s] found on interface %s\n",
 				    print_mac(nla_data(tb[NL80211_ATTR_MAC])), ifname);
-			ifindex = ctx->l3ctx->icmp6_ctx.ifindex;
-			clientmgr_notify_mac(CTX(clientmgr), nla_data(tb[NL80211_ATTR_MAC]), ifindex);
+			ifindex = l3ctx.icmp6_ctx.ifindex;
+			clientmgr_notify_mac(&l3ctx.clientmgr_ctx, nla_data(tb[NL80211_ATTR_MAC]), ifindex);
 			break;
 		case NL80211_CMD_DEL_STATION:
 			log_verbose(
 			    "NL80211_CMD_DEL_STATION for [%s] RECEIVED on "
 			    "interface %s.\n",
 			    print_mac(nla_data(tb[NL80211_ATTR_MAC])), ifname);
-			clientmgr_delete_client(CTX(clientmgr), nla_data(tb[NL80211_ATTR_MAC]));
+			clientmgr_delete_client(&l3ctx.clientmgr_ctx, nla_data(tb[NL80211_ATTR_MAC]));
 			break;
 	}
 

--- a/src/wifistations.c
+++ b/src/wifistations.c
@@ -28,8 +28,7 @@ static int no_seq_check(struct nl_msg *msg, void *arg) { return NL_OK; }
 void wifistations_handle_in(wifistations_ctx *ctx) { nl_recvmsgs(ctx->nl_sock, ctx->cb); }
 
 int wifistations_handle_event(struct nl_msg *msg, void *arg) {
-	if (l3ctx.debug)
-		printf("handling wifistations event\n");
+	log_debug("handling wifistations event\n");
 	wifistations_ctx *ctx = arg;
 	if (ctx->nl80211_disabled)
 		return 0;

--- a/src/wifistations.h
+++ b/src/wifistations.h
@@ -10,7 +10,6 @@ typedef struct {
 } wifistations_if;
 
 typedef struct {
-	struct l3ctx *l3ctx;
 	struct nl_sock *nl_sock;
 	struct nl_cb *cb;
 	VECTOR(wifistations_if) interfaces;


### PR DESCRIPTION
Without this patch, wire-only clients accumulate over time and are never removed from l3roamd as shown by https://grafana.bremen.freifunk.net/d/000000002/node?orgId=1&var-node=5254002a92c8&refresh=1m&from=1559635941032&to=1560240681032&var-saveinterval=60

This patchset improves the build system somewhat and resolves the issue observed in the bremen network.